### PR TITLE
feat: event payload implementation

### DIFF
--- a/Analytics/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics/Analytics.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		53BE94F22C94C75D0004E75A /* BasicStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BE94F12C94C75D0004E75A /* BasicStorage.swift */; };
 		53BE94F42C94D70D0004E75A /* MemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BE94F32C94D70D0004E75A /* MemoryStore.swift */; };
 		53C29E722C918F2400F2A8C3 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C29E712C918F2400F2A8C3 /* Storage.swift */; };
+		53C52C772CE34FF400A2BD31 /* MessageOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C52C762CE34FF400A2BD31 /* MessageOptions.swift */; };
 		53F4B6652CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F4B6642CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift */; };
 		53FD37772CB1B0C700DBA06B /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FD37732CB1B0C700DBA06B /* Plugin.swift */; };
 		53FD37782CB1B0C700DBA06B /* PluginChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FD37742CB1B0C700DBA06B /* PluginChain.swift */; };
@@ -78,6 +79,7 @@
 		53BE94F12C94C75D0004E75A /* BasicStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStorage.swift; sourceTree = "<group>"; };
 		53BE94F32C94D70D0004E75A /* MemoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStore.swift; sourceTree = "<group>"; };
 		53C29E712C918F2400F2A8C3 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
+		53C52C762CE34FF400A2BD31 /* MessageOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageOptions.swift; sourceTree = "<group>"; };
 		53F4B6642CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlushPolicyModuleTests.swift; sourceTree = "<group>"; };
 		53FD37732CB1B0C700DBA06B /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		53FD37742CB1B0C700DBA06B /* PluginChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginChain.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			isa = PBXGroup;
 			children = (
 				53A22A3C2C7472850059D6FE /* Message.swift */,
+				53C52C762CE34FF400A2BD31 /* MessageOptions.swift */,
 				53FD379F2CB5163C00DBA06B /* MessageManager.swift */,
 				53028E9A2CC97222007C3FDE /* MessageUploader.swift */,
 			);
@@ -373,6 +376,7 @@
 				5392AB952C6FC78F00369791 /* Configuration.swift in Sources */,
 				53BE94F42C94D70D0004E75A /* MemoryStore.swift in Sources */,
 				53FD37A22CB5258100DBA06B /* AsyncChannel.swift in Sources */,
+				53C52C772CE34FF400A2BD31 /* MessageOptions.swift in Sources */,
 				5304C9182CD3FF37003AFCC2 /* FlushPolicy.swift in Sources */,
 				53FD377D2CB1C2BE00DBA06B /* RudderStackDataPlanePlugin.swift in Sources */,
 				53BE94F22C94C75D0004E75A /* BasicStorage.swift in Sources */,

--- a/Analytics/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics/Analytics.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		53BE94F42C94D70D0004E75A /* MemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BE94F32C94D70D0004E75A /* MemoryStore.swift */; };
 		53C29E722C918F2400F2A8C3 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C29E712C918F2400F2A8C3 /* Storage.swift */; };
 		53C52C772CE34FF400A2BD31 /* MessageOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C52C762CE34FF400A2BD31 /* MessageOptions.swift */; };
+		53C52C792CE486A000A2BD31 /* MessageModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C52C782CE486A000A2BD31 /* MessageModuleTests.swift */; };
 		53F4B6652CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F4B6642CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift */; };
 		53FD37772CB1B0C700DBA06B /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FD37732CB1B0C700DBA06B /* Plugin.swift */; };
 		53FD37782CB1B0C700DBA06B /* PluginChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FD37742CB1B0C700DBA06B /* PluginChain.swift */; };
@@ -80,6 +81,7 @@
 		53BE94F32C94D70D0004E75A /* MemoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStore.swift; sourceTree = "<group>"; };
 		53C29E712C918F2400F2A8C3 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		53C52C762CE34FF400A2BD31 /* MessageOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageOptions.swift; sourceTree = "<group>"; };
+		53C52C782CE486A000A2BD31 /* MessageModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageModuleTests.swift; sourceTree = "<group>"; };
 		53F4B6642CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlushPolicyModuleTests.swift; sourceTree = "<group>"; };
 		53FD37732CB1B0C700DBA06B /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		53FD37742CB1B0C700DBA06B /* PluginChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginChain.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				5334858E2C9AB24E0029F88E /* StorageModuleTests.swift */,
 				53859EE62CB66C3200EAE483 /* DataPlaneModuleTests.swift */,
 				53F4B6642CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift */,
+				53C52C782CE486A000A2BD31 /* MessageModuleTests.swift */,
 			);
 			path = AnalyticsTests;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				53859EE72CB66C3200EAE483 /* DataPlaneModuleTests.swift in Sources */,
+				53C52C792CE486A000A2BD31 /* MessageModuleTests.swift in Sources */,
 				539E540D2C98CD7D00982E95 /* AnalyticsTests.swift in Sources */,
 				5334858F2C9AB24E0029F88E /* StorageModuleTests.swift in Sources */,
 				53F4B6652CDA5F6F00AE9B75 /* FlushPolicyModuleTests.swift in Sources */,

--- a/Analytics/Analytics/Base/AnalyticsClient.swift
+++ b/Analytics/Analytics/Base/AnalyticsClient.swift
@@ -33,8 +33,13 @@ extension AnalyticsClient {
     }
     
     // MARK: - Screen
-    public func screen(name: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
-        let event = ScreenEvent(screenName: name, properties: properties, options: options)
+    public func screen(name: String, category: String? = nil, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
+        
+        var updatedProperties = properties ?? RudderProperties()
+        updatedProperties["category"] = category?.isEmpty ?? true ? nil : category
+        updatedProperties["name"] = name.isEmpty ? nil : name
+        
+        let event = ScreenEvent(screenName: name, properties: updatedProperties, options: options)
         self.process(event: event)
     }
     

--- a/Analytics/Analytics/Base/AnalyticsClient.swift
+++ b/Analytics/Analytics/Base/AnalyticsClient.swift
@@ -44,7 +44,7 @@ extension AnalyticsClient {
     }
     
     // MARK: - Group
-    public func group(id: String, traits: RudderProperties? = nil, options: RudderOptions? = nil) {
+    public func group(id: String, traits: RudderTraits? = nil, options: RudderOptions? = nil) {
         let event = GroupEvent(groupId: id, traits: traits, options: options)
         self.process(event: event)
     }

--- a/Analytics/Analytics/Base/AnalyticsClient.swift
+++ b/Analytics/Analytics/Base/AnalyticsClient.swift
@@ -28,19 +28,19 @@ extension AnalyticsClient {
     
     // MARK: - Track
     public func track(name: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
-        let event = TrackEvent(event: name, properties: CodableCollection(dictionary: properties), options: CodableCollection(dictionary: options))
+        let event = TrackEvent(event: name, properties: properties, options: options)
         self.process(event: event)
     }
     
     // MARK: - Screen
     public func screen(name: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
-        let event = ScreenEvent(screenName: name, properties: CodableCollection(dictionary: properties), options: CodableCollection(dictionary: options))
+        let event = ScreenEvent(screenName: name, properties: properties, options: options)
         self.process(event: event)
     }
     
     // MARK: - Group
     public func group(id: String, traits: RudderProperties? = nil, options: RudderOptions? = nil) {
-        let event = GroupEvent(groupId: id, traits: CodableCollection(dictionary: traits), options: CodableCollection(dictionary: options))
+        let event = GroupEvent(groupId: id, traits: traits, options: options)
         self.process(event: event)
     }
     

--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -14,15 +14,24 @@ import Foundation
 protocol Message: Codable {
     var anonymousId: String? { get set }
     var channel: String? { get set }
+    var integrations: [String: Bool]? { get set }
     var sentAt: String? { get set }
-    
-//    var context: AnalyticsContext { get set }
-//    var userId: String? { get set }
-//    var integrations: [String: Bool]? { get set }
+    var context: [String: CodableCollection]? { get set }
     
     var type: EventType { get set }
     var messageId: String { get set }
     var originalTimeStamp: String { get set }
+}
+
+extension Message {
+    mutating func addDefaultValues() {
+        self.channel = Constants.defaultChannel
+        self.sentAt = Constants.defaultSentAtPlaceholder
+        
+        // TODO: Needs to be modified in future..
+        self.anonymousId = .randomUUIDString
+        //context
+    }
 }
 
 // MARK: - TrackEvent
@@ -33,16 +42,22 @@ struct TrackEvent: Message {
     
     var anonymousId: String?
     var channel: String?
+    var integrations: [String: Bool]?
     var sentAt: String?
+    var context: [String: CodableCollection]?
     
     var event: String
     var properties: CodableCollection?
-    var options: RudderOptions?
     
     init(event: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.event = event
         self.properties = CodableCollection(dictionary: properties)
-        self.options = options
+        self.integrations = options?.integrations
+        
+        self.context = options?.customContext?.isEmpty == false ?
+            options?.customContext?.compactMapValues { CodableCollection(dictionary: $0) } : nil
+        
+        self.addDefaultValues()
     }
 }
 
@@ -54,16 +69,19 @@ struct ScreenEvent: Message {
     
     var anonymousId: String?
     var channel: String?
+    var integrations: [String: Bool]?
     var sentAt: String?
+    var context: [String: CodableCollection]?
     
     var screenName: String
     var properties: CodableCollection?
-    var options: RudderOptions?
     
     init(screenName: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.screenName = screenName
         self.properties = CodableCollection(dictionary: properties)
-        self.options = options
+        self.integrations = options?.integrations
+        
+        self.addDefaultValues()
     }
 }
 
@@ -75,16 +93,19 @@ struct GroupEvent: Message {
     
     var anonymousId: String?
     var channel: String?
+    var integrations: [String: Bool]?
     var sentAt: String?
+    var context: [String: CodableCollection]?
     
     var groupId: String
     var traits: CodableCollection?
-    var options: RudderOptions?
     
     init(groupId: String, traits: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.groupId = groupId
         self.traits = CodableCollection(dictionary: traits)
-        self.options = options
+        self.integrations = options?.integrations
+        
+        self.addDefaultValues()
     }
 }
 
@@ -96,7 +117,9 @@ struct FlushEvent: Message {
     
     var anonymousId: String?
     var channel: String?
+    var integrations: [String: Bool]?
     var sentAt: String?
+    var context: [String: CodableCollection]?
     
     var messageName: String
     
@@ -111,53 +134,5 @@ enum EventType: String, CaseIterable, Codable {
     
     public var label: String {
         return rawValue.capitalized
-    }
-}
-
-// MARK: - RudderOptionType
-protocol RudderOptionType: Codable {
-    var integrations: [String: Bool]? { get set }
-    var customContext: CodableCollection? { get set }
-}
-
-// MARK: - RudderOptions
-public struct RudderOptions: RudderOptionType {
-    var integrations: [String: Bool]?
-    var customContext: CodableCollection?
-    
-    public init?(integrations: [String : Bool]? = nil, customContext: CodableCollection? = nil) {
-        guard integrations != nil || customContext != nil else { return nil }
-        self.integrations = integrations
-        self.customContext = customContext
-    }
-}
-
-// MARK: - RudderIdentifyOptionType
-protocol RudderIdentifyOptionType: RudderOptionType {
-    var externalIds: [ExternalId]? { get set }
-}
-
-// MARK: - RudderIdentifyOptions
-public struct RudderIdentifyOptions: RudderIdentifyOptionType {
-    var integrations: [String: Bool]?
-    var customContext: CodableCollection?
-    var externalIds: [ExternalId]?
-    
-    public init?(integrations: [String : Bool]? = nil, customContext: [String : Any]? = nil, externalIds: [ExternalId]? = nil) {
-        guard integrations != nil || externalIds != nil || customContext != nil else { return nil }
-        self.integrations = integrations
-        self.externalIds = externalIds
-        self.customContext = CodableCollection(dictionary: customContext)
-    }
-}
-
-// MARK: - ExternalId
-public struct ExternalId: Codable {
-    var type: String
-    var id: String
-    
-    public init(type: String, id: String) {
-        self.type = type
-        self.id = id
     }
 }

--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -12,6 +12,14 @@ import Foundation
  This is base class for all events.
  */
 protocol Message: Codable {
+    var anonymousId: String? { get set }
+    var channel: String? { get set }
+    var sentAt: String? { get set }
+    
+//    var context: AnalyticsContext { get set }
+//    var userId: String? { get set }
+//    var integrations: [String: Bool]? { get set }
+    
     var type: EventType { get set }
     var messageId: String { get set }
     var originalTimeStamp: String { get set }
@@ -19,80 +27,80 @@ protocol Message: Codable {
 
 // MARK: - TrackEvent
 struct TrackEvent: Message {
-    public var type: EventType
-    public var messageId: String
-    public var originalTimeStamp: String
+    var type: EventType = .track
+    var messageId: String = .randomUUIDString
+    var originalTimeStamp: String = .currentTimeStamp
     
-    public var event: String
-    public var properties: CodableCollection?
-    public var options: CodableCollection?
+    var anonymousId: String?
+    var channel: String?
+    var sentAt: String?
     
-    public init(event: String, properties: CodableCollection? = nil, options: CodableCollection? = nil) {
-        self.type = .track
-        self.messageId = .randomUUIDString
-        self.originalTimeStamp = .currentTimeStamp
-        
+    var event: String
+    var properties: CodableCollection?
+    var options: RudderOptions?
+    
+    init(event: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.event = event
-        self.properties = properties
+        self.properties = CodableCollection(dictionary: properties)
         self.options = options
     }
 }
 
 // MARK: - ScreenEvent
 struct ScreenEvent: Message {
-    public var type: EventType
-    public var messageId: String
-    public var originalTimeStamp: String
+    var type: EventType = .screen
+    var messageId: String = .randomUUIDString
+    var originalTimeStamp: String = .currentTimeStamp
     
-    public var screenName: String
-    public var properties: CodableCollection?
-    public var options: CodableCollection?
+    var anonymousId: String?
+    var channel: String?
+    var sentAt: String?
     
-    public init(screenName: String, properties: CodableCollection? = nil, options: CodableCollection? = nil) {
-        self.type = .screen
-        self.messageId = .randomUUIDString
-        self.originalTimeStamp = .currentTimeStamp
-        
+    var screenName: String
+    var properties: CodableCollection?
+    var options: RudderOptions?
+    
+    init(screenName: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.screenName = screenName
-        self.properties = properties
+        self.properties = CodableCollection(dictionary: properties)
         self.options = options
     }
 }
 
 // MARK: - GroupEvent
 struct GroupEvent: Message {
-    public var type: EventType
-    public var messageId: String
-    public var originalTimeStamp: String
+    var type: EventType = .group
+    var messageId: String = .randomUUIDString
+    var originalTimeStamp: String = .currentTimeStamp
     
-    public var groupId: String
-    public var traits: CodableCollection?
-    public var options: CodableCollection?
+    var anonymousId: String?
+    var channel: String?
+    var sentAt: String?
     
-    init(groupId: String, traits: CodableCollection? = nil, options: CodableCollection? = nil) {
-        self.type = .group
-        self.messageId = .randomUUIDString
-        self.originalTimeStamp = .currentTimeStamp
-        
+    var groupId: String
+    var traits: CodableCollection?
+    var options: RudderOptions?
+    
+    init(groupId: String, traits: RudderProperties? = nil, options: RudderOptions? = nil) {
         self.groupId = groupId
-        self.traits = traits
+        self.traits = CodableCollection(dictionary: traits)
         self.options = options
     }
 }
 
 // MARK: - FlushEvent
 struct FlushEvent: Message {
-    public var type: EventType
-    public var messageId: String
-    public var originalTimeStamp: String
+    var type: EventType = .flush
+    var messageId: String = .randomUUIDString
+    var originalTimeStamp: String = .currentTimeStamp
     
-    public var messageName: String
+    var anonymousId: String?
+    var channel: String?
+    var sentAt: String?
+    
+    var messageName: String
     
     init(messageName: String) {
-        self.type = .flush
-        self.messageId = .randomUUIDString
-        self.originalTimeStamp = .currentTimeStamp
-        
         self.messageName = messageName
     }
 }
@@ -103,5 +111,53 @@ enum EventType: String, CaseIterable, Codable {
     
     public var label: String {
         return rawValue.capitalized
+    }
+}
+
+// MARK: - RudderOptionType
+protocol RudderOptionType: Codable {
+    var integrations: [String: Bool]? { get set }
+    var customContext: CodableCollection? { get set }
+}
+
+// MARK: - RudderOptions
+public struct RudderOptions: RudderOptionType {
+    var integrations: [String: Bool]?
+    var customContext: CodableCollection?
+    
+    public init?(integrations: [String : Bool]? = nil, customContext: CodableCollection? = nil) {
+        guard integrations != nil || customContext != nil else { return nil }
+        self.integrations = integrations
+        self.customContext = customContext
+    }
+}
+
+// MARK: - RudderIdentifyOptionType
+protocol RudderIdentifyOptionType: RudderOptionType {
+    var externalIds: [ExternalId]? { get set }
+}
+
+// MARK: - RudderIdentifyOptions
+public struct RudderIdentifyOptions: RudderIdentifyOptionType {
+    var integrations: [String: Bool]?
+    var customContext: CodableCollection?
+    var externalIds: [ExternalId]?
+    
+    public init?(integrations: [String : Bool]? = nil, customContext: [String : Any]? = nil, externalIds: [ExternalId]? = nil) {
+        guard integrations != nil || externalIds != nil || customContext != nil else { return nil }
+        self.integrations = integrations
+        self.externalIds = externalIds
+        self.customContext = CodableCollection(dictionary: customContext)
+    }
+}
+
+// MARK: - ExternalId
+public struct ExternalId: Codable {
+    var type: String
+    var id: String
+    
+    public init(type: String, id: String) {
+        self.type = type
+        self.id = id
     }
 }

--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -73,13 +73,16 @@ struct ScreenEvent: Message {
     var sentAt: String?
     var context: [String: CodableCollection]?
     
-    var screenName: String
+    var event: String
     var properties: CodableCollection?
     
     init(screenName: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
-        self.screenName = screenName
+        self.event = screenName
         self.properties = CodableCollection(dictionary: properties)
         self.integrations = options?.integrations
+        
+        self.context = options?.customContext?.isEmpty == false ?
+            options?.customContext?.compactMapValues { CodableCollection(dictionary: $0) } : nil
         
         self.addDefaultValues()
     }

--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Message
 /**
- This is base class for all events.
+ This is base protocol for all events.
  */
 protocol Message: Codable {
     var anonymousId: String? { get set }
@@ -24,6 +24,9 @@ protocol Message: Codable {
 }
 
 extension Message {
+    /**
+     This function will serve as a shared utility for adding default or standard values.
+     */
     mutating func addDefaultValues() {
         self.channel = Constants.defaultChannel
         self.sentAt = Constants.defaultSentAtPlaceholder
@@ -35,6 +38,9 @@ extension Message {
 }
 
 // MARK: - TrackEvent
+/**
+ This model is based on the `Message` protocol and is designed for creating `Track` events.
+ */
 struct TrackEvent: Message {
     var type: EventType = .track
     var messageId: String = .randomUUIDString
@@ -62,6 +68,9 @@ struct TrackEvent: Message {
 }
 
 // MARK: - ScreenEvent
+/**
+ This model is based on the `Message` protocol and is designed for creating `Screen` events.
+ */
 struct ScreenEvent: Message {
     var type: EventType = .screen
     var messageId: String = .randomUUIDString
@@ -89,6 +98,9 @@ struct ScreenEvent: Message {
 }
 
 // MARK: - GroupEvent
+/**
+ This model is based on the `Message` protocol and is designed for creating `Group` events.
+ */
 struct GroupEvent: Message {
     var type: EventType = .group
     var messageId: String = .randomUUIDString
@@ -119,6 +131,9 @@ struct GroupEvent: Message {
 }
 
 // MARK: - FlushEvent
+/**
+ This model is based on the `Message` protocol and is designed for creating `Flush` events.
+ */
 struct FlushEvent: Message {
     var type: EventType = .flush
     var messageId: String = .randomUUIDString
@@ -138,6 +153,9 @@ struct FlushEvent: Message {
 }
 
 // MARK: - EventType
+/**
+ Enum values used to specify the type of message event.
+ */
 enum EventType: String, CaseIterable, Codable {
     case track, screen, group, flush
     

--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -16,7 +16,7 @@ protocol Message: Codable {
     var channel: String? { get set }
     var integrations: [String: Bool]? { get set }
     var sentAt: String? { get set }
-    var context: [String: CodableCollection]? { get set }
+    var context: [String: AnyCodable]? { get set }
     
     var type: EventType { get set }
     var messageId: String { get set }
@@ -44,7 +44,7 @@ struct TrackEvent: Message {
     var channel: String?
     var integrations: [String: Bool]?
     var sentAt: String?
-    var context: [String: CodableCollection]?
+    var context: [String: AnyCodable]?
     
     var event: String
     var properties: CodableCollection?
@@ -55,7 +55,7 @@ struct TrackEvent: Message {
         self.integrations = options?.integrations
         
         self.context = options?.customContext?.isEmpty == false ?
-            options?.customContext?.compactMapValues { CodableCollection(dictionary: $0) } : nil
+        options?.customContext?.compactMapValues { AnyCodable($0) } : nil
         
         self.addDefaultValues()
     }
@@ -71,7 +71,7 @@ struct ScreenEvent: Message {
     var channel: String?
     var integrations: [String: Bool]?
     var sentAt: String?
-    var context: [String: CodableCollection]?
+    var context: [String: AnyCodable]?
     
     var event: String
     var properties: CodableCollection?
@@ -82,7 +82,7 @@ struct ScreenEvent: Message {
         self.integrations = options?.integrations
         
         self.context = options?.customContext?.isEmpty == false ?
-            options?.customContext?.compactMapValues { CodableCollection(dictionary: $0) } : nil
+            options?.customContext?.compactMapValues { AnyCodable($0) } : nil
         
         self.addDefaultValues()
     }
@@ -98,17 +98,23 @@ struct GroupEvent: Message {
     var channel: String?
     var integrations: [String: Bool]?
     var sentAt: String?
-    var context: [String: CodableCollection]?
+    var context: [String: AnyCodable]?
     
     var groupId: String
     var traits: CodableCollection?
     
-    init(groupId: String, traits: RudderProperties? = nil, options: RudderOptions? = nil) {
+    init(groupId: String, traits: RudderTraits? = nil, options: RudderOptions? = nil) {
         self.groupId = groupId
-        self.traits = CodableCollection(dictionary: traits)
+        self.addDefaultValues()
+        
+        var updatedTraits = traits ?? RudderTraits()
+        updatedTraits["anonymousId"] = self.anonymousId
+        
+        self.traits = CodableCollection(dictionary: updatedTraits)
         self.integrations = options?.integrations
         
-        self.addDefaultValues()
+        self.context = options?.customContext?.isEmpty == false ?
+            options?.customContext?.compactMapValues { AnyCodable($0) } : nil
     }
 }
 
@@ -122,7 +128,7 @@ struct FlushEvent: Message {
     var channel: String?
     var integrations: [String: Bool]?
     var sentAt: String?
-    var context: [String: CodableCollection]?
+    var context: [String: AnyCodable]?
     
     var messageName: String
     

--- a/Analytics/Analytics/Events/MessageManager.swift
+++ b/Analytics/Analytics/Events/MessageManager.swift
@@ -95,7 +95,10 @@ extension MessageManager {
             
             for item in received {
                 print(item.batch)
-                let uItem = UploadItem(reference: item.reference, content: item.batch)
+                
+                let processed = item.batch.replacingOccurrences(of: Constants.defaultSentAtPlaceholder, with: Date().iso8601TimeStamp)
+                
+                let uItem = UploadItem(reference: item.reference, content: processed)
                 if !self.flushedReferences.contains(item.reference) {
                     self.flushedReferences.append(item.reference)
                     self.uploader?.addToQueue(uItem)

--- a/Analytics/Analytics/Events/MessageOptions.swift
+++ b/Analytics/Analytics/Events/MessageOptions.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 // MARK: - RudderOptionType
+/**
+ This is a base protocol for managing Rudder options.
+ */
 protocol RudderOptionType {
     var integrations: [String: Bool]? { get set }
     var customContext: [String: Any]? { get }
@@ -29,6 +32,9 @@ extension RudderOptionType {
 }
 
 // MARK: - RudderOptions
+/**
+ This class implements the `RudderOptionType` protocol, which is used to add options to message events.
+ */
 public class RudderOptions: RudderOptionType {
     internal(set) public var integrations: [String: Bool]?
     private(set) public var customContext: [String: Any]?
@@ -47,54 +53,5 @@ public class RudderOptions: RudderOptionType {
     public func addCustomContext(_ context:Any, key: String) -> Self {
         self.addCustomContext(&self.customContext, values: [key: context])
         return self
-    }
-}
-
-
-// MARK: - RudderIdentifyOptionType
-protocol RudderIdentifyOptionType: RudderOptionType {
-    var externalIds: [ExternalId]? { get }
-}
-
-// MARK: - RudderIdentifyOptions
-public class RudderIdentifyOptions: RudderIdentifyOptionType {
-    internal(set) public var integrations: [String: Bool]?
-    private(set) public var customContext: [String: Any]?
-    private(set) public var externalIds: [ExternalId]?
-    
-    public init() {
-        self.integrations = Constants.defaultIntegration
-    }
-    
-    @discardableResult
-    public func addIntegration(_ integration: String, isEnabled: Bool) -> Self {
-        self.addIntegration(&self.integrations, values: [integration: isEnabled])
-        return self
-    }
-    
-    @discardableResult
-    public func addCustomContext(_ context:Any, key: String) -> Self {
-        self.addCustomContext(&self.customContext, values: [key: context])
-        return self
-    }
-    
-    @discardableResult
-    public func addExternalId(_ id: ExternalId) -> Self {
-        if self.integrations == nil { self.externalIds = [] }
-        
-        self.externalIds?.append(id)
-        return self
-    }
-}
-
-
-// MARK: - ExternalId
-public struct ExternalId: Codable {
-    var type: String
-    var id: String
-    
-    public init(type: String, id: String) {
-        self.type = type
-        self.id = id
     }
 }

--- a/Analytics/Analytics/Events/MessageOptions.swift
+++ b/Analytics/Analytics/Events/MessageOptions.swift
@@ -10,10 +10,10 @@ import Foundation
 // MARK: - RudderOptionType
 protocol RudderOptionType {
     var integrations: [String: Bool]? { get set }
-    var customContext: [String: [String: Any]]? { get }
+    var customContext: [String: Any]? { get }
     
     func addIntegration(_ integration: String, isEnabled: Bool) -> Self
-    func addCustomContext(_ context: [String: Any], key: String) -> Self
+    func addCustomContext(_ context: Any, key: String) -> Self
 }
 
 extension RudderOptionType {
@@ -22,7 +22,7 @@ extension RudderOptionType {
         integrations?.merge(values, uniquingKeysWith: { $1 })
     }
     
-    func addCustomContext(_ context: inout [String: [String: Any]]?, values: [String: [String: Any]]) {
+    func addCustomContext(_ context: inout [String: Any]?, values: [String: Any]) {
         if context == nil { context = [:] }
         context?.merge(values, uniquingKeysWith: { $1 })
     }
@@ -31,7 +31,7 @@ extension RudderOptionType {
 // MARK: - RudderOptions
 public class RudderOptions: RudderOptionType {
     internal(set) public var integrations: [String: Bool]?
-    private(set) public var customContext: [String: [String: Any]]?
+    private(set) public var customContext: [String: Any]?
     
     public init() {
         self.integrations = Constants.defaultIntegration
@@ -44,7 +44,7 @@ public class RudderOptions: RudderOptionType {
     }
     
     @discardableResult
-    public func addCustomContext(_ context:[String: Any], key: String) -> Self {
+    public func addCustomContext(_ context:Any, key: String) -> Self {
         self.addCustomContext(&self.customContext, values: [key: context])
         return self
     }
@@ -59,7 +59,7 @@ protocol RudderIdentifyOptionType: RudderOptionType {
 // MARK: - RudderIdentifyOptions
 public class RudderIdentifyOptions: RudderIdentifyOptionType {
     internal(set) public var integrations: [String: Bool]?
-    private(set) public var customContext: [String: [String: Any]]?
+    private(set) public var customContext: [String: Any]?
     private(set) public var externalIds: [ExternalId]?
     
     public init() {
@@ -73,7 +73,7 @@ public class RudderIdentifyOptions: RudderIdentifyOptionType {
     }
     
     @discardableResult
-    public func addCustomContext(_ context:[String: Any], key: String) -> Self {
+    public func addCustomContext(_ context:Any, key: String) -> Self {
         self.addCustomContext(&self.customContext, values: [key: context])
         return self
     }

--- a/Analytics/Analytics/Events/MessageOptions.swift
+++ b/Analytics/Analytics/Events/MessageOptions.swift
@@ -1,0 +1,100 @@
+//
+//  MessageOptions.swift
+//  Analytics
+//
+//  Created by Satheesh Kannan on 12/11/24.
+//
+
+import Foundation
+
+// MARK: - RudderOptionType
+protocol RudderOptionType {
+    var integrations: [String: Bool]? { get set }
+    var customContext: [String: [String: Any]]? { get }
+    
+    func addIntegration(_ integration: String, isEnabled: Bool) -> Self
+    func addCustomContext(_ context: [String: Any], key: String) -> Self
+}
+
+extension RudderOptionType {
+    func addIntegration(_ integrations: inout [String: Bool]?, values: [String: Bool]) {
+        if integrations == nil { integrations = Constants.defaultIntegration }
+        integrations?.merge(values, uniquingKeysWith: { $1 })
+    }
+    
+    func addCustomContext(_ context: inout [String: [String: Any]]?, values: [String: [String: Any]]) {
+        if context == nil { context = [:] }
+        context?.merge(values, uniquingKeysWith: { $1 })
+    }
+}
+
+// MARK: - RudderOptions
+public class RudderOptions: RudderOptionType {
+    internal(set) public var integrations: [String: Bool]?
+    private(set) public var customContext: [String: [String: Any]]?
+    
+    public init() {
+        self.integrations = Constants.defaultIntegration
+    }
+    
+    @discardableResult
+    public func addIntegration(_ integration: String, isEnabled: Bool) -> Self {
+        self.addIntegration(&self.integrations, values: [integration: isEnabled])
+        return self
+    }
+    
+    @discardableResult
+    public func addCustomContext(_ context:[String: Any], key: String) -> Self {
+        self.addCustomContext(&self.customContext, values: [key: context])
+        return self
+    }
+}
+
+
+// MARK: - RudderIdentifyOptionType
+protocol RudderIdentifyOptionType: RudderOptionType {
+    var externalIds: [ExternalId]? { get }
+}
+
+// MARK: - RudderIdentifyOptions
+public class RudderIdentifyOptions: RudderIdentifyOptionType {
+    internal(set) public var integrations: [String: Bool]?
+    private(set) public var customContext: [String: [String: Any]]?
+    private(set) public var externalIds: [ExternalId]?
+    
+    public init() {
+        self.integrations = Constants.defaultIntegration
+    }
+    
+    @discardableResult
+    public func addIntegration(_ integration: String, isEnabled: Bool) -> Self {
+        self.addIntegration(&self.integrations, values: [integration: isEnabled])
+        return self
+    }
+    
+    @discardableResult
+    public func addCustomContext(_ context:[String: Any], key: String) -> Self {
+        self.addCustomContext(&self.customContext, values: [key: context])
+        return self
+    }
+    
+    @discardableResult
+    public func addExternalId(_ id: ExternalId) -> Self {
+        if self.integrations == nil { self.externalIds = [] }
+        
+        self.externalIds?.append(id)
+        return self
+    }
+}
+
+
+// MARK: - ExternalId
+public struct ExternalId: Codable {
+    var type: String
+    var id: String
+    
+    public init(type: String, id: String) {
+        self.type = type
+        self.id = id
+    }
+}

--- a/Analytics/Analytics/Helpers/Extensions.swift
+++ b/Analytics/Analytics/Helpers/Extensions.swift
@@ -29,6 +29,17 @@ extension String {
     var trimmedUrlString: String {
         return self.hasSuffix("/") ? String(self.dropLast()) : self
     }
+    
+    var asDictionary: [String: Any]? {
+        guard let data = self.utf8Data else { return nil }
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            return jsonObject as? [String: Any]
+        } catch {
+            print("Error converting string to dictionary: \(error)")
+            return nil
+        }
+    }
 }
 
 // MARK: - DateFormatter

--- a/Analytics/Analytics/Helpers/Extensions.swift
+++ b/Analytics/Analytics/Helpers/Extensions.swift
@@ -15,12 +15,7 @@ extension String {
     }
     
     static var currentTimeStamp: String {
-        return String.timeStampFromDate(Date()).replacingOccurrences(of: "+00:00", with: "Z")
-    }
-    
-    static func timeStampFromDate(_ date: Date) -> String {
-        let formattedDate = DateFormatter.timeStampFormat.string(from: date)
-        return formattedDate.replacingOccurrences(of: "+00:00", with: "Z")
+        return Date().iso8601TimeStamp
     }
     
     var utf8Data: Data? {
@@ -38,11 +33,21 @@ extension String {
 
 // MARK: - DateFormatter
 extension DateFormatter {
-    static var timeStampFormat: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-        formatter.timeZone = TimeZone(abbreviation: "UTC")
+    static var timeStampFormat: ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
+    }
+}
+
+// MARK: - Date
+extension Date {
+    var iso8601TimeStamp: String {
+        return DateFormatter.timeStampFormat.string(from: self)
+    }
+    
+    func date(from timeStamp: String) -> Date? {
+        return DateFormatter.timeStampFormat.date(from: timeStamp)
     }
 }
 

--- a/Analytics/Analytics/Helpers/Helpers.swift
+++ b/Analytics/Analytics/Helpers/Helpers.swift
@@ -9,6 +9,7 @@ import Foundation
 
 // MARK: - Typealiases(Public)
 public typealias RudderProperties = [String: Any]
+public typealias RudderTraits = [String: Any]
 public typealias VoidClosure = () -> Void
 
 // MARK: - Typealiases(Internal)

--- a/Analytics/Analytics/Helpers/Helpers.swift
+++ b/Analytics/Analytics/Helpers/Helpers.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 // MARK: - Typealiases(Public)
-public typealias RudderOptions = [String: Any]
 public typealias RudderProperties = [String: Any]
 public typealias VoidClosure = () -> Void
 
@@ -37,6 +36,7 @@ public struct Constants {
     static let configQueryParams = ["p": "ios", "v": "1.29.1"]
     static let uploadSignal = "#!upload!#"
     
+    static let defaultChannel = "mobile"
     private init() {}
 }
 

--- a/Analytics/Analytics/Helpers/Helpers.swift
+++ b/Analytics/Analytics/Helpers/Helpers.swift
@@ -37,6 +37,9 @@ public struct Constants {
     static let uploadSignal = "#!upload!#"
     
     static let defaultChannel = "mobile"
+    static let defaultIntegration = ["All": true]
+    static let defaultSentAtPlaceholder = "{{_RSA_DEF_SENT_AT_TS_}}"
+    
     private init() {}
 }
 

--- a/Analytics/AnalyticsTests/AnalyticsTests.swift
+++ b/Analytics/AnalyticsTests/AnalyticsTests.swift
@@ -56,7 +56,7 @@ extension AnalyticsTests {
     
     func test_trackEvent_disk() {
         guard let client = analytics_disk else { return XCTFail("No disk client") }
-        client.track(name: "Track Event", properties: ["prop": "value"], options: ["opt": "val"])
+        client.track(name: "Track Event", properties: ["prop": "value"])
         client.configuration.storage.rollover(nil)
         
         let dataItems = client.configuration.storage.read().dataItems
@@ -66,7 +66,7 @@ extension AnalyticsTests {
     func test_flushEvents_disk() {
         MockProvider.resetDiskStorage()
         guard let client = analytics_disk else { return XCTFail("No disk client") }
-        client.track(name: "Track Event", properties: ["prop": "value"], options: ["opt": "val"])
+        client.track(name: "Track Event", properties: ["prop": "value"])
         client.flush()
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         

--- a/Analytics/AnalyticsTests/AnalyticsTests.swift
+++ b/Analytics/AnalyticsTests/AnalyticsTests.swift
@@ -20,7 +20,7 @@ final class AnalyticsTests: XCTestCase {
         
         self.analytics_disk?.configuration.storage.remove(key: StorageKeys.anonymousId)
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         
@@ -57,10 +57,40 @@ extension AnalyticsTests {
     func test_trackEvent_disk() {
         guard let client = analytics_disk else { return XCTFail("No disk client") }
         client.track(name: "Track Event", properties: ["prop": "value"])
-        client.configuration.storage.rollover(nil)
-        
-        let dataItems = client.configuration.storage.read().dataItems
-        XCTAssertFalse(dataItems.isEmpty)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.3))
+        client.configuration.storage.rollover {
+            let dataItems = client.configuration.storage.read().dataItems
+            XCTAssertFalse(dataItems.isEmpty)
+            dataItems.forEach { client.configuration.storage.remove(messageReference: $0.reference) }
+        }
+    }
+    
+    func test_screenEvent_disk() {
+        guard let client = analytics_disk else { return XCTFail("No disk client") }
+        client.screen(name: "Screen Event", category: "Main", properties: ["prop": "value"])
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.3))
+        client.configuration.storage.rollover {
+            let dataItems = client.configuration.storage.read().dataItems
+            XCTAssertFalse(dataItems.isEmpty)
+            
+            guard let dictionary = dataItems.first?.batch.asDictionary as? [String: Any] else { XCTFail(); return }
+            
+            guard let properties = dictionary["properties"] as? [String: Any] else { XCTFail(); return }
+            
+            XCTAssertEqual(properties["category"] as? String, "Main")
+            dataItems.forEach { client.configuration.storage.remove(messageReference: $0.reference) }
+        }
+    }
+    
+    func test_groupEvent_disk() {
+        guard let client = analytics_disk else { return XCTFail("No disk client") }
+        client.group(id: "group_id", traits: ["prop": "value"])
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.3))
+        client.configuration.storage.rollover {
+            let dataItems = client.configuration.storage.read().dataItems
+            XCTAssertFalse(dataItems.isEmpty)
+            dataItems.forEach { client.configuration.storage.remove(messageReference: $0.reference) }
+        }
     }
     
     func test_flushEvents_disk() {
@@ -68,7 +98,6 @@ extension AnalyticsTests {
         guard let client = analytics_disk else { return XCTFail("No disk client") }
         client.track(name: "Track Event", properties: ["prop": "value"])
         client.flush()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         
         let dataItems = client.configuration.storage.read().dataItems
         XCTAssertFalse(dataItems.isEmpty) //Should be false.. Since no proper dataplane configured...

--- a/Analytics/AnalyticsTests/MessageModuleTests.swift
+++ b/Analytics/AnalyticsTests/MessageModuleTests.swift
@@ -1,0 +1,118 @@
+//
+//  MessageModuleTests.swift
+//  AnalyticsTests
+//
+//  Created by Satheesh Kannan on 13/11/24.
+//
+
+import XCTest
+@testable import Analytics
+
+final class MessageModuleTests: XCTestCase {
+    
+    func test_track_event() {
+        given("Parameters to create a track event") {
+            let event = "Sample Event"
+            
+            when("Create a track event") {
+                let track = TrackEvent(event: event)
+                
+                then("Verify the track event") {
+                    XCTAssertEqual(track.event, event)
+                    XCTAssertEqual(track.type, .track)
+                    XCTAssertFalse(track.messageId.isEmpty)
+                    XCTAssertFalse(track.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(track.anonymousId)
+                    XCTAssertEqual(track.channel, Constants.defaultChannel)
+                    XCTAssertNil(track.integrations)
+                    XCTAssertFalse(track.sentAt?.isEmpty ?? true)
+                    XCTAssertNil(track.properties)
+                }
+            }
+        }
+    }
+    
+    func test_track_event_properties() {
+        given("Parameters to create a track event") {
+            let event = "Sample Event"
+            let properties: [String: String] = ["property": "value"]
+            
+            when("Create a track event") {
+                let track = TrackEvent(event: event, properties: properties)
+                
+                then("Verify the track event") {
+                    XCTAssertEqual(track.event, event)
+                    
+                    XCTAssertEqual(track.type, .track)
+                    XCTAssertFalse(track.messageId.isEmpty)
+                    XCTAssertFalse(track.originalTimeStamp.isEmpty)
+                    
+                    XCTAssertNotNil(track.anonymousId)
+                    XCTAssertEqual(track.channel, Constants.defaultChannel)
+                    XCTAssertFalse(track.sentAt?.isEmpty ?? true)
+                    
+                    XCTAssertNil(track.integrations)
+                    XCTAssertNotNil(track.properties)
+                }
+                
+            }
+        }
+    }
+    
+    func test_track_event_options() {
+        given("Parameters to create a track event") {
+            let event = "Sample Event"
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a track event") {
+                let track = TrackEvent(event: event, options: options)
+                
+                then("Verify the track event") {
+                    XCTAssertEqual(track.event, event)
+                    XCTAssertEqual(track.type, .track)
+                    XCTAssertFalse(track.messageId.isEmpty)
+                    XCTAssertFalse(track.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(track.anonymousId)
+                    XCTAssertEqual(track.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(track.integrations)
+                    XCTAssertFalse(track.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(track.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(track.context?.isEmpty ?? true)
+                    XCTAssertNil(track.properties)
+                }
+                
+            }
+        }
+    }
+    
+    func test_track_event_properties_options() {
+        given("Parameters to create a track event") {
+            let event = "Sample Event"
+            let properties: [String: String] = ["property": "value"]
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a track event") {
+                let track = TrackEvent(event: event, properties: properties, options: options)
+                
+                then("Verify the track event") {
+                    XCTAssertEqual(track.event, event)
+                    XCTAssertEqual(track.type, .track)
+                    XCTAssertFalse(track.messageId.isEmpty)
+                    XCTAssertFalse(track.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(track.anonymousId)
+                    XCTAssertEqual(track.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(track.integrations)
+                    XCTAssertFalse(track.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(track.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(track.context?.isEmpty ?? true)
+                    XCTAssertNotNil(track.properties)
+                }
+                
+            }
+        }
+    }
+}

--- a/Analytics/AnalyticsTests/MessageModuleTests.swift
+++ b/Analytics/AnalyticsTests/MessageModuleTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 final class MessageModuleTests: XCTestCase {
     
+    // MARK: - Track
     func test_track_event() {
         given("Parameters to create a track event") {
             let event = "Sample Event"
@@ -112,6 +113,321 @@ final class MessageModuleTests: XCTestCase {
                     XCTAssertNotNil(track.properties)
                 }
                 
+            }
+        }
+    }
+    
+    func test_track_event_custom_context() {
+        given("Fully loaded custom context option") {
+            let event = "Sample Event"
+            let option = RudderOptions()
+            .addIntegration("SDK", isEnabled: true)
+            .addIntegration("Segment", isEnabled: false)
+            .addCustomContext(["Key1": "Value1"], key: "SK1")
+            .addCustomContext(["value1", "value2"], key: "SK2")
+            .addCustomContext("Value3", key: "SK3")
+            .addCustomContext(1234, key: "SK4")
+            .addCustomContext(5678.9, key: "SK5")
+            .addCustomContext(true, key: "SK6")
+            
+            when("Create a track event") {
+                let track = TrackEvent(event: event, options: option)
+                
+                then("Verify the track event") {
+                    XCTAssertEqual(track.event, event)
+                    XCTAssertEqual(track.type, .track)
+                    XCTAssertFalse(track.messageId.isEmpty)
+                    XCTAssertFalse(track.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(track.anonymousId)
+                    XCTAssertEqual(track.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(track.integrations)
+                    XCTAssertFalse(track.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(track.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(track.context?.isEmpty ?? true)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Screen
+    func test_screen_event() {
+        given("Parameters to create a screen event") {
+            let name = "Sample Screen Event"
+            
+            when("Create a screen event") {
+                let screen = ScreenEvent(screenName: name)
+                
+                then("Verify the screen event") {
+                    XCTAssertEqual(screen.event, name)
+                    XCTAssertEqual(screen.type, .screen)
+                    XCTAssertFalse(screen.messageId.isEmpty)
+                    XCTAssertFalse(screen.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(screen.anonymousId)
+                    XCTAssertEqual(screen.channel, Constants.defaultChannel)
+                    XCTAssertNil(screen.integrations)
+                    XCTAssertFalse(screen.sentAt?.isEmpty ?? true)
+                    XCTAssertNil(screen.properties)
+                }
+            }
+        }
+    }
+    
+    func test_screen_event_properties() {
+        given("Parameters to create a screen event") {
+            let name = "Sample Screen Event"
+            let properties: [String: String] = ["property": "value"]
+            
+            when("Create a screen event") {
+                let screen = ScreenEvent(screenName: name, properties: properties)
+                
+                then("Verify the screen event") {
+                    XCTAssertEqual(screen.event, name)
+                    
+                    XCTAssertEqual(screen.type, .screen)
+                    XCTAssertFalse(screen.messageId.isEmpty)
+                    XCTAssertFalse(screen.originalTimeStamp.isEmpty)
+                    
+                    XCTAssertNotNil(screen.anonymousId)
+                    XCTAssertEqual(screen.channel, Constants.defaultChannel)
+                    XCTAssertFalse(screen.sentAt?.isEmpty ?? true)
+                    
+                    XCTAssertNil(screen.integrations)
+                    XCTAssertNotNil(screen.properties)
+                }
+                
+            }
+        }
+    }
+    
+    func test_screen_event_options() {
+        given("Parameters to create a screen event") {
+            let name = "Sample Screen Event"
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a screen event") {
+                let screen = ScreenEvent(screenName: name, options: options)
+                
+                then("Verify the screen event") {
+                    XCTAssertEqual(screen.event, name)
+                    XCTAssertEqual(screen.type, .screen)
+                    XCTAssertFalse(screen.messageId.isEmpty)
+                    XCTAssertFalse(screen.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(screen.anonymousId)
+                    XCTAssertEqual(screen.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(screen.integrations)
+                    XCTAssertFalse(screen.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(screen.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(screen.context?.isEmpty ?? true)
+                    XCTAssertNil(screen.properties)
+                }
+                
+            }
+        }
+    }
+    
+    func test_screen_event_properties_options() {
+        given("Parameters to create a screen event") {
+            let name = "Sample Screen Event"
+            let properties: [String: String] = ["property": "value"]
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a screen event") {
+                let screen = ScreenEvent(screenName: name, properties: properties, options: options)
+                
+                then("Verify the screen event") {
+                    XCTAssertEqual(screen.event, name)
+                    XCTAssertEqual(screen.type, .screen)
+                    XCTAssertFalse(screen.messageId.isEmpty)
+                    XCTAssertFalse(screen.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(screen.anonymousId)
+                    XCTAssertEqual(screen.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(screen.integrations)
+                    XCTAssertFalse(screen.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(screen.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(screen.context?.isEmpty ?? true)
+                    XCTAssertNotNil(screen.properties)
+                }
+                
+            }
+        }
+    }
+    
+    func test_screen_event_custom_context() {
+        given("Fully loaded custom context option") {
+            let name = "Sample Screen Event"
+            let option = RudderOptions()
+            .addIntegration("SDK", isEnabled: true)
+            .addIntegration("Segment", isEnabled: false)
+            .addCustomContext(["Key1": "Value1"], key: "SK1")
+            .addCustomContext(["value1", "value2"], key: "SK2")
+            .addCustomContext("Value3", key: "SK3")
+            .addCustomContext(1234, key: "SK4")
+            .addCustomContext(5678.9, key: "SK5")
+            .addCustomContext(true, key: "SK6")
+            
+            when("Create a screen event") {
+                let screen = ScreenEvent(screenName: name, options: option)
+                
+                then("Verify the screen event") {
+                    XCTAssertEqual(screen.event, name)
+                    XCTAssertEqual(screen.type, .screen)
+                    XCTAssertFalse(screen.messageId.isEmpty)
+                    XCTAssertFalse(screen.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(screen.anonymousId)
+                    XCTAssertEqual(screen.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(screen.integrations)
+                    XCTAssertFalse(screen.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(screen.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(screen.context?.isEmpty ?? true)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Group
+    func test_group_event() {
+        given("Parameters to create a group event") {
+            let groupId = "Sample_Group_Id"
+            
+            when("Create a group event") {
+                let group = GroupEvent(groupId: groupId)
+                
+                then("Verify the group event") {
+                    XCTAssertEqual(group.groupId, groupId)
+                    XCTAssertEqual(group.type, .group)
+                    XCTAssertFalse(group.messageId.isEmpty)
+                    XCTAssertFalse(group.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(group.anonymousId)
+                    XCTAssertEqual(group.channel, Constants.defaultChannel)
+                    XCTAssertNil(group.integrations)
+                    XCTAssertFalse(group.sentAt?.isEmpty ?? true)
+                    XCTAssertNotNil(group.traits)
+                    XCTAssertTrue((group.traits?.dictionary?.count == 1))
+                }
+            }
+        }
+    }
+    
+    func test_group_event_traits() {
+        given("Parameters to create a group event") {
+            let groupId = "Sample_Group_Id"
+            let traits = ["property": "value"]
+            
+            when("Create a group event") {
+                let group = GroupEvent(groupId: groupId, traits: traits)
+                
+                then("Verify the group event") {
+                    XCTAssertEqual(group.groupId, groupId)
+                    
+                    XCTAssertEqual(group.type, .group)
+                    XCTAssertFalse(group.messageId.isEmpty)
+                    XCTAssertFalse(group.originalTimeStamp.isEmpty)
+                    
+                    XCTAssertNotNil(group.anonymousId)
+                    XCTAssertEqual(group.channel, Constants.defaultChannel)
+                    XCTAssertFalse(group.sentAt?.isEmpty ?? true)
+                    
+                    XCTAssertNil(group.integrations)
+                    XCTAssertNotNil(group.traits)
+                    XCTAssertTrue((group.traits?.dictionary?.count == 2))
+                }
+                
+            }
+        }
+    }
+    
+    func test_group_event_options() {
+        given("Parameters to create a group event") {
+            let groupId = "Sample_Group_Id"
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a group event") {
+                let group = GroupEvent(groupId: groupId, options: options)
+                
+                then("Verify the group event") {
+                    XCTAssertEqual(group.groupId, groupId)
+                    XCTAssertEqual(group.type, .group)
+                    XCTAssertFalse(group.messageId.isEmpty)
+                    XCTAssertFalse(group.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(group.anonymousId)
+                    XCTAssertEqual(group.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(group.integrations)
+                    XCTAssertFalse(group.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(group.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(group.context?.isEmpty ?? true)
+                    XCTAssertNotNil(group.traits)
+                }
+                
+            }
+        }
+    }
+    
+    func test_group_event_properties_options() {
+        given("Parameters to create a group event") {
+            let groupId = "Sample_Group_Id"
+            let traits = ["property": "value"]
+            let options = RudderOptions()
+                .addIntegration("SampleIntegration", isEnabled: false)
+                .addCustomContext(["userContext": "content"], key: "customContext")
+            
+            when("Create a group event") {
+                let group = GroupEvent(groupId: groupId, traits: traits, options: options)
+                
+                then("Verify the group event") {
+                    XCTAssertEqual(group.groupId, groupId)
+                    XCTAssertEqual(group.type, .group)
+                    XCTAssertFalse(group.messageId.isEmpty)
+                    XCTAssertFalse(group.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(group.anonymousId)
+                    XCTAssertEqual(group.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(group.integrations)
+                    XCTAssertFalse(group.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(group.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(group.context?.isEmpty ?? true)
+                    XCTAssertNotNil(group.traits)
+                    XCTAssertTrue((group.traits?.dictionary?.count == 2))
+                }
+                
+            }
+        }
+    }
+    
+    func test_group_event_custom_context() {
+        given("Fully loaded custom context option") {
+            let groupId = "Sample_Group_Id"
+            let option = RudderOptions()
+            .addIntegration("SDK", isEnabled: true)
+            .addIntegration("Segment", isEnabled: false)
+            .addCustomContext(["Key1": "Value1"], key: "SK1")
+            .addCustomContext(["value1", "value2"], key: "SK2")
+            .addCustomContext("Value3", key: "SK3")
+            .addCustomContext(1234, key: "SK4")
+            .addCustomContext(5678.9, key: "SK5")
+            .addCustomContext(true, key: "SK6")
+            
+            when("Create a group event") {
+                let group = GroupEvent(groupId: groupId, options: option)
+                
+                then("Verify the group event") {
+                    XCTAssertEqual(group.groupId, groupId)
+                    XCTAssertEqual(group.type, .group)
+                    XCTAssertFalse(group.messageId.isEmpty)
+                    XCTAssertFalse(group.originalTimeStamp.isEmpty)
+                    XCTAssertNotNil(group.anonymousId)
+                    XCTAssertEqual(group.channel, Constants.defaultChannel)
+                    XCTAssertNotNil(group.integrations)
+                    XCTAssertFalse(group.integrations?.isEmpty ?? true)
+                    XCTAssertFalse(group.sentAt?.isEmpty ?? true)
+                    XCTAssertFalse(group.context?.isEmpty ?? true)
+                    XCTAssertNotNil(group.traits)
+                    XCTAssertTrue((group.traits?.dictionary?.count == 1))
+                }
             }
         }
     }

--- a/Analytics/AnalyticsTests/MessageModuleTests.swift
+++ b/Analytics/AnalyticsTests/MessageModuleTests.swift
@@ -122,7 +122,7 @@ final class MessageModuleTests: XCTestCase {
             let event = "Sample Event"
             let option = RudderOptions()
             .addIntegration("SDK", isEnabled: true)
-            .addIntegration("Segment", isEnabled: false)
+            .addIntegration("Facebook", isEnabled: false)
             .addCustomContext(["Key1": "Value1"], key: "SK1")
             .addCustomContext(["value1", "value2"], key: "SK2")
             .addCustomContext("Value3", key: "SK3")
@@ -261,7 +261,7 @@ final class MessageModuleTests: XCTestCase {
             let name = "Sample Screen Event"
             let option = RudderOptions()
             .addIntegration("SDK", isEnabled: true)
-            .addIntegration("Segment", isEnabled: false)
+            .addIntegration("Facebook", isEnabled: false)
             .addCustomContext(["Key1": "Value1"], key: "SK1")
             .addCustomContext(["value1", "value2"], key: "SK2")
             .addCustomContext("Value3", key: "SK3")
@@ -403,7 +403,7 @@ final class MessageModuleTests: XCTestCase {
             let groupId = "Sample_Group_Id"
             let option = RudderOptions()
             .addIntegration("SDK", isEnabled: true)
-            .addIntegration("Segment", isEnabled: false)
+            .addIntegration("Facebook", isEnabled: false)
             .addCustomContext(["Key1": "Value1"], key: "SK1")
             .addCustomContext(["value1", "value2"], key: "SK2")
             .addCustomContext("Value3", key: "SK3")

--- a/Analytics/AnalyticsTests/MockProvider.swift
+++ b/Analytics/AnalyticsTests/MockProvider.swift
@@ -15,7 +15,7 @@ final class MockProvider {
     static let _mockWriteKey = "MoCk_WrItEkEy"
     
     static let simpleTrackEvent: TrackEvent = {
-        let event = TrackEvent(event: "Track_Event", properties: CodableCollection(dictionary: ["Property_1": "Value1"]), options: CodableCollection(dictionary: ["Property_1": "Value1"]))
+        let event = TrackEvent(event: "Track_Event", properties: ["Property_1": "Value1"], options: RudderOptions().addCustomContext(["context_key": "context_value"], key: "custom_context"))
         return event
     }()
 }

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -17,8 +17,12 @@ struct ContentView: View {
                     let option = RudderOptions()
                     .addIntegration("SDK", isEnabled: true)
                     .addIntegration("Segment", isEnabled: false)
-                    .addCustomContext(["Key123": "Value123"], key: "SK123")
-                    .addCustomContext(["Key1234": "Value1234"], key: "SK1234")
+                    .addCustomContext(["Key1": "Value1"], key: "SK1")
+                    .addCustomContext(["value1", "value2"], key: "SK2")
+                    .addCustomContext("Value3", key: "SK3")
+                    .addCustomContext(1234, key: "SK4")
+                    .addCustomContext(5678.9, key: "SK5")
+                    .addCustomContext(true, key: "SK6")
                     
                     AnalyticsManager.shared.analytics?.track(name: "Track at \(Date())", properties: ["key": "value"], options: option)
                 }

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -15,8 +15,8 @@ struct ContentView: View {
             HStack {
                 CustomButton(title: "Track") {
                     let option = RudderOptions()
-                    .addIntegration("SDK", isEnabled: true)
-                    .addIntegration("Segment", isEnabled: false)
+                    .addIntegration("Amplitude", isEnabled: true)
+                    .addIntegration("CleverTap", isEnabled: false)
                     .addCustomContext(["Key1": "Value1"], key: "SK1")
                     .addCustomContext(["value1", "value2"], key: "SK2")
                     .addCustomContext("Value3", key: "SK3")
@@ -29,8 +29,8 @@ struct ContentView: View {
                 
                 CustomButton(title: "Multiple Track") {
                     let option = RudderOptions()
-                    .addIntegration("SDK", isEnabled: true)
-                    .addIntegration("Segment", isEnabled: false)
+                    .addIntegration("Amplitude", isEnabled: true)
+                    .addIntegration("CleverTap", isEnabled: false)
                     .addCustomContext(["Key123": "Value123"], key: "SK123")
                     
                     for i in 1...50 {
@@ -50,7 +50,7 @@ struct ContentView: View {
                 CustomButton(title: "Group") {
                     let option = RudderOptions()
                         .addCustomContext(["Key1": "Value1"], key: "SK")
-                        .addIntegration("MySDK", isEnabled: false)
+                        .addIntegration("Firebase", isEnabled: false)
                     AnalyticsManager.shared.analytics?.group(id: "group_id", traits: ["key": "value"], options: option)
                 }
             }

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Analytics
 
 struct ContentView: View {
     
@@ -13,23 +14,40 @@ struct ContentView: View {
         VStack {
             HStack {
                 CustomButton(title: "Track") {
-                    AnalyticsManager.shared.analytics?.track(name: "Track at \(Date())", properties: ["key": "value"], options: ["option": "value"])
+                    let option = RudderOptions()
+                    .addIntegration("SDK", isEnabled: true)
+                    .addIntegration("Segment", isEnabled: false)
+                    .addCustomContext(["Key123": "Value123"], key: "SK123")
+                    .addCustomContext(["Key1234": "Value1234"], key: "SK1234")
+                    
+                    AnalyticsManager.shared.analytics?.track(name: "Track at \(Date())", properties: ["key": "value"], options: option)
                 }
                 
                 CustomButton(title: "Multiple Track") {
+                    let option = RudderOptions()
+                    .addIntegration("SDK", isEnabled: true)
+                    .addIntegration("Segment", isEnabled: false)
+                    .addCustomContext(["Key123": "Value123"], key: "SK123")
+                    
                     for i in 1...50 {
-                        AnalyticsManager.shared.analytics?.track(name: "Track: \(i)")
+                        AnalyticsManager.shared.analytics?.track(name: "Track: \(i)", options: option)
                     }
                 }
             }
             
             HStack {
                 CustomButton(title: "Screen") {
-                    AnalyticsManager.shared.analytics?.screen(name: "Analytics Screen", properties: ["key": "value"], options: ["option": "value"])
+                    let option = RudderOptions()
+                        .addCustomContext(["Key1": "Value1"], key: "SK")
+                        .addIntegration("Segment", isEnabled: false)
+                    AnalyticsManager.shared.analytics?.screen(name: "Analytics Screen", properties: ["key": "value"], options: option)
                 }
                 
                 CustomButton(title: "Group") {
-                    AnalyticsManager.shared.analytics?.group(id: "group_id", traits: ["key": "value"], options: ["option": "value"])
+                    let option = RudderOptions()
+                        .addCustomContext(["Key1": "Value1"], key: "SK")
+                        .addIntegration("MySDK", isEnabled: false)
+                    AnalyticsManager.shared.analytics?.group(id: "group_id", traits: ["key": "value"], options: option)
                 }
             }
             

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -43,7 +43,7 @@ struct ContentView: View {
                 CustomButton(title: "Screen") {
                     let option = RudderOptions()
                         .addCustomContext(["Key1": "Value1"], key: "SK")
-                        .addIntegration("Segment", isEnabled: false)
+                        .addIntegration("Facebook", isEnabled: false)
                     AnalyticsManager.shared.analytics?.screen(name: "Analytics Screen", properties: ["key": "value"], options: option)
                 }
                 


### PR DESCRIPTION
## Description
This PR includes the payload implementation for Track, Screen, and Group events.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
Each event contains several common fields in addition to fields unique to that specific event type. This PR implements all the common fields for events. Additionally, it introduces the `RudderOptions` model to manage `integrations` and `customContext` values. The `RudderIdentifyOptions` model is also introduced and will be utilized in future event implementations.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

To run the sample app, configure the necessary values such as the write key and data plane URL in the AnalyticsApp class. The data plane will receive the Track, Screen, and Group events.

Sample Track Event JSON:
```
{
    "anonymousId": "CC23B8E5-5D97-4225-9E5C-03DF5947F303",
    "channel": "mobile",
    "context": {
        "SK1": {
            "Key1": "Value1"
        },
        "SK2": [
            "value1",
            "value2"
        ],
        "SK3": "Value3",
        "SK4": 1234,
        "SK5": 5678.9,
        "SK6": true
    },
    "event": "Track at 2024-11-14 18:01:51 +0000",
    "integrations": {
        "All": true,
        "SDK": true,
        "Segment": false
    },
    "messageId": "40F9AA0A-33A6-4AAF-A08E-26692F532F56",
    "originalTimeStamp": "2024-11-14T18:01:51.700Z",
    "properties": {
        "key": "value"
    },
    "receivedAt": "2024-11-14T18:02:00.305Z",
    "request_ip": "106.51.148.64",
    "rudderId": "2836452c-f55b-40aa-aef2-b79476455727",
    "sentAt": "2024-11-14T18:01:58.144Z",
    "type": "track"
}
```

Sample Screen Event JSON:
```
{
    "anonymousId": "E30C3220-8ECC-4746-83B7-657F214975D7",
    "channel": "mobile",
    "context": {
        "SK": {
            "Key1": "Value1"
        }
    },
    "event": "Analytics Screen",
    "integrations": {
        "All": true,
        "Segment": false
    },
    "messageId": "458C7801-D471-4039-9CEF-E44D2013FE97",
    "originalTimeStamp": "2024-11-14T18:04:58.558Z",
    "properties": {
        "key": "value",
        "name": "Analytics Screen"
    },
    "receivedAt": "2024-11-14T18:05:09.035Z",
    "request_ip": "106.51.148.64",
    "rudderId": "d11cbd78-d252-4bf6-a29f-6eee75b74220",
    "sentAt": "2024-11-14T18:05:08.134Z",
    "type": "screen"
}
```

Sample Group Event JSON:
```
{
    "anonymousId": "4EC697F2-9BD2-4016-AD2C-7756E4C59CA3",
    "channel": "mobile",
    "context": {
        "SK": {
            "Key1": "Value1"
        }
    },
    "groupId": "group_id",
    "integrations": {
        "All": true,
        "MySDK": false
    },
    "messageId": "F1EB4361-CCDA-40A1-89D1-D098C9EE4F7E",
    "originalTimeStamp": "2024-11-14T18:05:36.376Z",
    "receivedAt": "2024-11-14T18:05:38.283Z",
    "request_ip": "106.51.148.64",
    "rudderId": "75bdfd20-2cd2-4d52-8b7b-88c0cf71660b",
    "sentAt": "2024-11-14T18:05:38.132Z",
    "traits": {
        "anonymousId": "4EC697F2-9BD2-4016-AD2C-7756E4C59CA3",
        "key": "value"
    },
    "type": "group"
}
```
