### PR TITLE
feat: create advertising id plugin

### DIFF
--- a/Analytics/Analytics/Events/Message.swift
+++ b/Analytics/Analytics/Events/Message.swift
@@ -96,7 +96,7 @@ extension Message {
 
      - Note: If the `context` property is `nil`, it is initialized with the provided context.
      */
-    func addToContext(info: [String: Any]) -> any Message {
+    public func addToContext(info: [String: Any]) -> any Message {
         var mutableSelf = self
         mutableSelf.context = (mutableSelf.context ?? [:]) + info.mapValues { AnyCodable($0) }
         return mutableSelf

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -16,6 +16,16 @@
 		5383D2C72D3E95FC00291B00 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */; };
 		5383D2C92D3E97C700291B00 /* AdvertisingIdPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383D2C82D3E97C700291B00 /* AdvertisingIdPlugin.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5383D2D22D3EAC0C00291B00 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5351AA712C6BE9DE003C3C47 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5351AA782C6BE9DE003C3C47;
+			remoteInfo = AnalyticsApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		5351AA8E2C6BEA02003C3C47 /* Embed Frameworks */ = {
@@ -40,7 +50,12 @@
 		5351AA8B2C6BEA02003C3C47 /* Analytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Analytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		5383D2C82D3E97C700291B00 /* AdvertisingIdPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingIdPlugin.swift; sourceTree = "<group>"; };
+		5383D2CE2D3EAC0C00291B00 /* AnalyticsAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AnalyticsAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		5383D2CF2D3EAC0C00291B00 /* AnalyticsAppTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AnalyticsAppTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		5351AA762C6BE9DE003C3C47 /* Frameworks */ = {
@@ -51,6 +66,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5383D2CB2D3EAC0C00291B00 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -58,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				5351AA7B2C6BE9DE003C3C47 /* AnalyticsApp */,
+				5383D2CF2D3EAC0C00291B00 /* AnalyticsAppTests */,
 				5351AA7A2C6BE9DE003C3C47 /* Products */,
 				5351AA8A2C6BEA02003C3C47 /* Frameworks */,
 			);
@@ -67,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				5351AA792C6BE9DE003C3C47 /* AnalyticsApp.app */,
+				5383D2CE2D3EAC0C00291B00 /* AnalyticsAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -121,6 +145,29 @@
 			productReference = 5351AA792C6BE9DE003C3C47 /* AnalyticsApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		5383D2CD2D3EAC0C00291B00 /* AnalyticsAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5383D2D42D3EAC0C00291B00 /* Build configuration list for PBXNativeTarget "AnalyticsAppTests" */;
+			buildPhases = (
+				5383D2CA2D3EAC0C00291B00 /* Sources */,
+				5383D2CB2D3EAC0C00291B00 /* Frameworks */,
+				5383D2CC2D3EAC0C00291B00 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5383D2D32D3EAC0C00291B00 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				5383D2CF2D3EAC0C00291B00 /* AnalyticsAppTests */,
+			);
+			name = AnalyticsAppTests;
+			packageProductDependencies = (
+			);
+			productName = AnalyticsAppTests;
+			productReference = 5383D2CE2D3EAC0C00291B00 /* AnalyticsAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -128,11 +175,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1540;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					5351AA782C6BE9DE003C3C47 = {
 						CreatedOnToolsVersion = 15.4;
+					};
+					5383D2CD2D3EAC0C00291B00 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 5351AA782C6BE9DE003C3C47;
 					};
 				};
 			};
@@ -150,6 +201,7 @@
 			projectRoot = "";
 			targets = (
 				5351AA782C6BE9DE003C3C47 /* AnalyticsApp */,
+				5383D2CD2D3EAC0C00291B00 /* AnalyticsAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -161,6 +213,13 @@
 			files = (
 				5351AA842C6BE9E0003C3C47 /* Preview Assets.xcassets in Resources */,
 				5351AA812C6BE9E0003C3C47 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5383D2CC2D3EAC0C00291B00 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,7 +237,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5383D2CA2D3EAC0C00291B00 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5383D2D32D3EAC0C00291B00 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5351AA782C6BE9DE003C3C47 /* AnalyticsApp */;
+			targetProxy = 5383D2D22D3EAC0C00291B00 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		5351AA852C6BE9E0003C3C47 /* Debug */ = {
@@ -362,6 +436,50 @@
 			};
 			name = Release;
 		};
+		5383D2D52D3EAC0C00291B00 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sk.AnalyticsAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AnalyticsApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AnalyticsApp";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		5383D2D62D3EAC0C00291B00 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sk.AnalyticsAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AnalyticsApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AnalyticsApp";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -379,6 +497,15 @@
 			buildConfigurations = (
 				5351AA882C6BE9E0003C3C47 /* Debug */,
 				5351AA892C6BE9E0003C3C47 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5383D2D42D3EAC0C00291B00 /* Build configuration list for PBXNativeTarget "AnalyticsAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5383D2D52D3EAC0C00291B00 /* Debug */,
+				5383D2D62D3EAC0C00291B00 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"AnalyticsApp/Preview Content\"";
-				DEVELOPMENT_TEAM = UT5XGH477Q;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app needs Bluetooth access to enhance your experience.";
@@ -413,7 +413,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"AnalyticsApp/Preview Content\"";
-				DEVELOPMENT_TEAM = UT5XGH477Q;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app needs Bluetooth access to enhance your experience.";

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app needs Bluetooth access to enhance your experience.";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "This app needs Tracking access to improve your experience.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -334,6 +335,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app needs Bluetooth access to enhance your experience.";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "This app needs Tracking access to improve your experience.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5351AA842C6BE9E0003C3C47 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5351AA832C6BE9E0003C3C47 /* Preview Assets.xcassets */; };
 		5351AA8C2C6BEA02003C3C47 /* Analytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5351AA8B2C6BEA02003C3C47 /* Analytics.framework */; };
 		5351AA8D2C6BEA02003C3C47 /* Analytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5351AA8B2C6BEA02003C3C47 /* Analytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5383D2C72D3E95FC00291B00 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -36,6 +37,7 @@
 		5351AA802C6BE9E0003C3C47 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5351AA832C6BE9E0003C3C47 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5351AA8B2C6BEA02003C3C47 /* Analytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Analytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +74,7 @@
 			children = (
 				5351AA7C2C6BE9DE003C3C47 /* AnalyticsApp.swift */,
 				5351AA7E2C6BE9DE003C3C47 /* ContentView.swift */,
+				5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */,
 				5351AA802C6BE9E0003C3C47 /* Assets.xcassets */,
 				5351AA822C6BE9E0003C3C47 /* Preview Content */,
 			);
@@ -165,6 +168,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5383D2C72D3E95FC00291B00 /* AnalyticsManager.swift in Sources */,
 				5351AA7F2C6BE9DE003C3C47 /* ContentView.swift in Sources */,
 				5351AA7D2C6BE9DE003C3C47 /* AnalyticsApp.swift in Sources */,
 			);

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5351AA8C2C6BEA02003C3C47 /* Analytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5351AA8B2C6BEA02003C3C47 /* Analytics.framework */; };
 		5351AA8D2C6BEA02003C3C47 /* Analytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5351AA8B2C6BEA02003C3C47 /* Analytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5383D2C72D3E95FC00291B00 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */; };
+		5383D2C92D3E97C700291B00 /* AdvertisingIdPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383D2C82D3E97C700291B00 /* AdvertisingIdPlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -38,6 +39,7 @@
 		5351AA832C6BE9E0003C3C47 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5351AA8B2C6BEA02003C3C47 /* Analytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Analytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
+		5383D2C82D3E97C700291B00 /* AdvertisingIdPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingIdPlugin.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +77,7 @@
 				5351AA7C2C6BE9DE003C3C47 /* AnalyticsApp.swift */,
 				5351AA7E2C6BE9DE003C3C47 /* ContentView.swift */,
 				5383D2C62D3E95FC00291B00 /* AnalyticsManager.swift */,
+				5383D2C82D3E97C700291B00 /* AdvertisingIdPlugin.swift */,
 				5351AA802C6BE9E0003C3C47 /* Assets.xcassets */,
 				5351AA822C6BE9E0003C3C47 /* Preview Content */,
 			);
@@ -168,6 +171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5383D2C92D3E97C700291B00 /* AdvertisingIdPlugin.swift in Sources */,
 				5383D2C72D3E95FC00291B00 /* AnalyticsManager.swift in Sources */,
 				5351AA7F2C6BE9DE003C3C47 /* ContentView.swift in Sources */,
 				5351AA7D2C6BE9DE003C3C47 /* AnalyticsApp.swift in Sources */,

--- a/AnalyticsApp/AnalyticsApp.xcodeproj/xcshareddata/xcschemes/AnalyticsApp.xcscheme
+++ b/AnalyticsApp/AnalyticsApp.xcodeproj/xcshareddata/xcschemes/AnalyticsApp.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5383D2CD2D3EAC0C00291B00"
+               BuildableName = "AnalyticsAppTests.xctest"
+               BlueprintName = "AnalyticsAppTests"
+               ReferencedContainer = "container:AnalyticsApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
+++ b/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
@@ -40,6 +40,8 @@ class AdvertisingIdPlugin: Plugin {
         
         // Add the IDFA to the device context
         deviceContent["advertisingId"] = advertisingId
+        deviceContent["adTrackingEnabled"] = true
+        
         return event.addToContext(info: ["device": deviceContent])
     }
 }

--- a/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
+++ b/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
@@ -9,6 +9,10 @@ import Analytics
 import AdSupport
 import AppTrackingTransparency
 
+// MARK: - AdvertisingIdPlugin
+/**
+ This class is a pre-processing plugin that retrieves the IDFA (Identifier for Advertisers) when tracking is authorized and adds it to the context of an event.
+ */
 class AdvertisingIdPlugin: Plugin {
     var pluginType: PluginType = .preProcess
     var analytics: AnalyticsClient?

--- a/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
+++ b/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
@@ -5,4 +5,34 @@
 //  Created by Satheesh Kannan on 20/01/25.
 //
 
-import Foundation
+import Analytics
+import AdSupport
+import AppTrackingTransparency
+
+class AdvertisingIdPlugin: Plugin {
+    
+    var pluginType: PluginType = .preProcess
+    var analytics: AnalyticsClient?
+    
+    func setup(analytics: AnalyticsClient) {
+        self.analytics = analytics
+    }
+    
+    func execute(event: any Message) -> (any Message)? {
+        guard let advertisingId = self.advertisementId else { return event }
+        
+        var deviceContent = [String: Any]()
+        if let deviceInfo = event.context?["device"]?.value as? [String: Any] {
+            deviceInfo.forEach { deviceContent[$0.key] = $0.value }
+        }
+        
+        // Add the IDFA to the device context
+        deviceContent["advertisingId"] = advertisingId
+        return event.addToContext(info: ["device": deviceContent])
+    }
+    
+    var advertisementId: String? {
+        guard ATTrackingManager.trackingAuthorizationStatus == .authorized else { return nil }
+        return ASIdentifierManager.shared().advertisingIdentifier.uuidString
+    }
+}

--- a/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
+++ b/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
@@ -10,16 +10,24 @@ import AdSupport
 import AppTrackingTransparency
 
 class AdvertisingIdPlugin: Plugin {
-    
     var pluginType: PluginType = .preProcess
     var analytics: AnalyticsClient?
+    
+    var trackingAuthorizationStatus: () -> ATTrackingManager.AuthorizationStatus = {
+        return ATTrackingManager.trackingAuthorizationStatus
+    }
+    var getAdvertisingId: () -> String? = {
+        return ASIdentifierManager.shared().advertisingIdentifier.uuidString
+    }
     
     func setup(analytics: AnalyticsClient) {
         self.analytics = analytics
     }
     
     func execute(event: any Message) -> (any Message)? {
-        guard let advertisingId = self.advertisementId else { return event }
+        guard trackingAuthorizationStatus() == .authorized, let advertisingId = getAdvertisingId() else {
+            return event
+        }
         
         var deviceContent = [String: Any]()
         if let deviceInfo = event.context?["device"]?.value as? [String: Any] {
@@ -29,10 +37,5 @@ class AdvertisingIdPlugin: Plugin {
         // Add the IDFA to the device context
         deviceContent["advertisingId"] = advertisingId
         return event.addToContext(info: ["device": deviceContent])
-    }
-    
-    var advertisementId: String? {
-        guard ATTrackingManager.trackingAuthorizationStatus == .authorized else { return nil }
-        return ASIdentifierManager.shared().advertisingIdentifier.uuidString
     }
 }

--- a/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
+++ b/AnalyticsApp/AnalyticsApp/AdvertisingIdPlugin.swift
@@ -1,0 +1,8 @@
+//
+//  AdvertisingIdPlugin.swift
+//  AnalyticsApp
+//
+//  Created by Satheesh Kannan on 20/01/25.
+//
+
+import Foundation

--- a/AnalyticsApp/AnalyticsApp/AnalyticsApp.swift
+++ b/AnalyticsApp/AnalyticsApp/AnalyticsApp.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Analytics
 
 // MARK: - AnalyticsAppApp
 @main
@@ -26,26 +25,5 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         AnalyticsManager.shared.initializeAnalyticsSDK()
         return true
-    }
-}
-
-// MARK: - AnalyticsManager
-class AnalyticsManager: Logger {
-    
-    static let shared = AnalyticsManager()
-    
-    var analytics: AnalyticsClient?
-   
-    private init() {}
-    
-    func initializeAnalyticsSDK() {
-        let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com", logger: self)
-        self.analytics = AnalyticsClient(configuration: config)
-    }
-    
-    var currentLogLevel: LogLevel = .debug
-    
-    func debug(tag: String, log: String) {
-        print("\(tag) : \(log)")
     }
 }

--- a/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
+++ b/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
@@ -1,0 +1,33 @@
+//
+//  AnalyticsManager.swift
+//  AnalyticsApp
+//
+//  Created by Satheesh Kannan on 20/01/25.
+//
+
+import Foundation
+import Analytics
+
+// MARK: - AnalyticsManager
+class AnalyticsManager {
+    
+    static let shared = AnalyticsManager()
+    private init() {}
+    
+    private var analytics: AnalyticsClient?
+    
+    func initializeAnalyticsSDK() {
+        let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com", logger: self)
+        self.analytics = AnalyticsClient(configuration: config)
+    }
+}
+
+extension AnalyticsManager: Logger {
+    
+    var currentLogLevel: LogLevel { .debug }
+    
+    func debug(tag: String, log: String) {
+        print("\(tag) : \(log)")
+    }
+}
+

--- a/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
+++ b/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
@@ -19,6 +19,9 @@ class AnalyticsManager {
     func initializeAnalyticsSDK() {
         let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com", logger: self)
         self.analytics = AnalyticsClient(configuration: config)
+        
+        //Add external plugin to analytics..
+        self.analytics?.addPlugin(AdvertisingIdPlugin())
     }
 }
 

--- a/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
+++ b/AnalyticsApp/AnalyticsApp/AnalyticsManager.swift
@@ -22,6 +22,31 @@ class AnalyticsManager {
     }
 }
 
+// MARK: - Rudder methods
+extension AnalyticsManager {
+    func track(name: String, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
+        self.analytics?.track(name: name, properties: properties, options: options)
+    }
+    
+    func screen(name: String, category: String? = nil, properties: RudderProperties? = nil, options: RudderOptions? = nil) {
+        self.analytics?.screen(name: name, category: category, properties: properties, options: options)
+    }
+    
+    func group(id: String, traits: RudderTraits? = nil, options: RudderOptions? = nil) {
+        self.analytics?.group(id: id, traits: traits, options: options)
+    }
+    
+    func flush() {
+        self.analytics?.flush()
+    }
+    
+    var anonymousId: String? {
+        get { self.analytics?.anonymousId }
+        set { if let newId = newValue { self.analytics?.anonymousId = newId } }
+    }
+}
+
+// MARK: - Logger
 extension AnalyticsManager: Logger {
     
     var currentLogLevel: LogLevel { .debug }

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 import Analytics
+import AdSupport
+import AppTrackingTransparency
 
 struct ContentView: View {
     
@@ -15,26 +17,26 @@ struct ContentView: View {
             HStack {
                 CustomButton(title: "Track") {
                     let option = RudderOptions()
-                    .addIntegration("Amplitude", isEnabled: true)
-                    .addIntegration("CleverTap", isEnabled: false)
-                    .addCustomContext(["Key1": "Value1"], key: "SK1")
-                    .addCustomContext(["value1", "value2"], key: "SK2")
-                    .addCustomContext("Value3", key: "SK3")
-                    .addCustomContext(1234, key: "SK4")
-                    .addCustomContext(5678.9, key: "SK5")
-                    .addCustomContext(true, key: "SK6")
+                        .addIntegration("Amplitude", isEnabled: true)
+                        .addIntegration("CleverTap", isEnabled: false)
+                        .addCustomContext(["Key1": "Value1"], key: "SK1")
+                        .addCustomContext(["value1", "value2"], key: "SK2")
+                        .addCustomContext("Value3", key: "SK3")
+                        .addCustomContext(1234, key: "SK4")
+                        .addCustomContext(5678.9, key: "SK5")
+                        .addCustomContext(true, key: "SK6")
                     
-                    AnalyticsManager.shared.analytics?.track(name: "Track at \(Date())", properties: ["key": "value"], options: option)
+                    AnalyticsManager.shared.track(name: "Track at \(Date())", properties: ["key": "value"], options: option)
                 }
                 
                 CustomButton(title: "Multiple Track") {
                     let option = RudderOptions()
-                    .addIntegration("Amplitude", isEnabled: true)
-                    .addIntegration("CleverTap", isEnabled: false)
-                    .addCustomContext(["Key123": "Value123"], key: "SK123")
+                        .addIntegration("Amplitude", isEnabled: true)
+                        .addIntegration("CleverTap", isEnabled: false)
+                        .addCustomContext(["Key123": "Value123"], key: "SK123")
                     
                     for i in 1...50 {
-                        AnalyticsManager.shared.analytics?.track(name: "Track: \(i)", options: option)
+                        AnalyticsManager.shared.track(name: "Track: \(i)", options: option)
                     }
                 }
             }
@@ -44,29 +46,49 @@ struct ContentView: View {
                     let option = RudderOptions()
                         .addCustomContext(["Key1": "Value1"], key: "SK")
                         .addIntegration("Facebook", isEnabled: false)
-                    AnalyticsManager.shared.analytics?.screen(name: "Analytics Screen", properties: ["key": "value"], options: option)
+                    AnalyticsManager.shared.screen(name: "Analytics Screen", properties: ["key": "value"], options: option)
                 }
                 
                 CustomButton(title: "Group") {
                     let option = RudderOptions()
                         .addCustomContext(["Key1": "Value1"], key: "SK")
                         .addIntegration("Firebase", isEnabled: false)
-                    AnalyticsManager.shared.analytics?.group(id: "group_id", traits: ["key": "value"], options: option)
+                    AnalyticsManager.shared.group(id: "group_id", traits: ["key": "value"], options: option)
                 }
             }
             
             HStack {
                 CustomButton(title: "Flush") {
-                    AnalyticsManager.shared.analytics?.flush()
+                    AnalyticsManager.shared.flush()
                 }
             }
             
             CustomButton(title: "Update AnonymousId") {
-                AnalyticsManager.shared.analytics?.anonymousId = "new_anonymous_id"
+                AnalyticsManager.shared.anonymousId = "new_anonymous_id"
             }
             
             CustomButton(title: "Read AnonymousId") {
-                print("Current Anonymous Id: \(String(describing: AnalyticsManager.shared.analytics?.anonymousId))")
+                print("Current Anonymous Id: \(String(describing: AnalyticsManager.shared.anonymousId))")
+            }
+        }
+        .onAppear {
+            self.confirmTrackingPermission()
+        }
+    }
+}
+
+extension ContentView {
+    func confirmTrackingPermission() {
+        print("Requesting Tracking Permission...")
+        Task {
+            let status = await ATTrackingManager.requestTrackingAuthorization()
+            print("Tracking Status: \(status.rawValue)")
+            
+            if status == .authorized {
+                let idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+                print("IDFA: \(idfa)")
+            } else {
+                print("Tracking not authorized.")
             }
         }
     }

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -80,13 +80,14 @@ struct ContentView: View {
 extension ContentView {
     func confirmTrackingPermission() {
         print("Requesting Tracking Permission...")
-        Task {
+        Task.detached {
             let status = await ATTrackingManager.requestTrackingAuthorization()
             print("Tracking Status: \(status.rawValue)")
             
             if status == .authorized {
                 let idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
                 print("IDFA: \(idfa)")
+                print("Tracking authorized.")
             } else {
                 print("Tracking not authorized.")
             }

--- a/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
@@ -1,0 +1,8 @@
+//
+//  AdvertisingIdPluginTests.swift
+//  AnalyticsAppTests
+//
+//  Created by Satheesh Kannan on 20/01/25.
+//
+
+import Foundation

--- a/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
@@ -26,10 +26,10 @@ struct AdvertisingIdPluginTests {
             plugin.trackingAuthorizationStatus = { .authorized }
             plugin.getAdvertisingId = { mockIdfa }
             
-            when("execute the plugin..") {
+            when("execute the plugin using mock event..") {
                 let result = plugin.execute(event: event)
                 
-                then("check the result..") {
+                then("check the result if advertisingId is added or not..") {
                     #expect(result != nil)
                     guard let deviceContent = result?.context?["device"]?.value as? [String: Any],
                           let idfa = deviceContent["advertisingId"] as? String else { #expect(1 == 0, "advertisingId not found.."); return}
@@ -57,10 +57,10 @@ struct AdvertisingIdPluginTests {
             plugin.trackingAuthorizationStatus = { .denied }
             plugin.getAdvertisingId = { mockIdfa }
             
-            when("execute the plugin..") {
+            when("execute the plugin using mock event..") {
                 let result = plugin.execute(event: event)
                 
-                then("check the result..") {
+                then("check the result if advertisingId is added or not..") {
                     #expect(result != nil)
                     guard let deviceContent = result?.context?["device"]?.value as? [String: Any] else { #expect(1 == 0, "deviceContent not found.."); return}
                     #expect(deviceContent["advertisingId"] == nil)

--- a/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
@@ -17,17 +17,17 @@ struct AdvertisingIdPluginTests {
             let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
             let analytics = AnalyticsClient(configuration: config)
             
-            let plugin = AdvertisingIdPlugin()
-            analytics.addPlugin(plugin)
+            let advertisingIdPlugin = AdvertisingIdPlugin()
+            analytics.addPlugin(advertisingIdPlugin)
             
             let mockIdfa = "mock_idfa_1234"
             let event = MockEvent()
             
-            plugin.trackingAuthorizationStatus = { .authorized }
-            plugin.getAdvertisingId = { mockIdfa }
+            advertisingIdPlugin.trackingAuthorizationStatus = { .authorized }
+            advertisingIdPlugin.getAdvertisingId = { mockIdfa }
             
             when("execute the plugin using mock event..") {
-                let result = plugin.execute(event: event)
+                let result = advertisingIdPlugin.execute(event: event)
                 
                 then("check the result if advertisingId is added or not..") {
                     #expect(result != nil)
@@ -45,8 +45,8 @@ struct AdvertisingIdPluginTests {
             let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
             let analytics = AnalyticsClient(configuration: config)
             
-            let plugin = AdvertisingIdPlugin()
-            analytics.addPlugin(plugin)
+            let advertisingIdPlugin = AdvertisingIdPlugin()
+            analytics.addPlugin(advertisingIdPlugin)
             
             let mockIdfa = "mock_idfa_1234"
             var event = MockEvent()
@@ -54,11 +54,11 @@ struct AdvertisingIdPluginTests {
                 event = modified
             }
             
-            plugin.trackingAuthorizationStatus = { .denied }
-            plugin.getAdvertisingId = { mockIdfa }
+            advertisingIdPlugin.trackingAuthorizationStatus = { .denied }
+            advertisingIdPlugin.getAdvertisingId = { mockIdfa }
             
             when("execute the plugin using mock event..") {
-                let result = plugin.execute(event: event)
+                let result = advertisingIdPlugin.execute(event: event)
                 
                 then("check the result if advertisingId is added or not..") {
                     #expect(result != nil)

--- a/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AdvertisingIdPluginTests.swift
@@ -5,4 +5,67 @@
 //  Created by Satheesh Kannan on 20/01/25.
 //
 
-import Foundation
+import Testing
+import Analytics
+@testable import AnalyticsApp
+
+struct AdvertisingIdPluginTests {
+    
+    @Test
+    func test_checkAdvertisingId_whenAuthorized() {
+        given("Prepare the environment when authorized..") {
+            let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
+            let analytics = AnalyticsClient(configuration: config)
+            
+            let plugin = AdvertisingIdPlugin()
+            analytics.addPlugin(plugin)
+            
+            let mockIdfa = "mock_idfa_1234"
+            let event = MockEvent()
+            
+            plugin.trackingAuthorizationStatus = { .authorized }
+            plugin.getAdvertisingId = { mockIdfa }
+            
+            when("execute the plugin..") {
+                let result = plugin.execute(event: event)
+                
+                then("check the result..") {
+                    #expect(result != nil)
+                    guard let deviceContent = result?.context?["device"]?.value as? [String: Any],
+                          let idfa = deviceContent["advertisingId"] as? String else { #expect(1 == 0, "advertisingId not found.."); return}
+                    #expect(idfa == mockIdfa)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_checkAdvertisingId_whenDenied() {
+        given("Prepare the environment when denied..") {
+            let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
+            let analytics = AnalyticsClient(configuration: config)
+            
+            let plugin = AdvertisingIdPlugin()
+            analytics.addPlugin(plugin)
+            
+            let mockIdfa = "mock_idfa_1234"
+            var event = MockEvent()
+            if let modified = event.addToContext(info: ["device": ["sample_key": "sample_value"]]) as? MockEvent {
+                event = modified
+            }
+            
+            plugin.trackingAuthorizationStatus = { .denied }
+            plugin.getAdvertisingId = { mockIdfa }
+            
+            when("execute the plugin..") {
+                let result = plugin.execute(event: event)
+                
+                then("check the result..") {
+                    #expect(result != nil)
+                    guard let deviceContent = result?.context?["device"]?.value as? [String: Any] else { #expect(1 == 0, "deviceContent not found.."); return}
+                    #expect(deviceContent["advertisingId"] == nil)
+                }
+            }
+        }
+    }
+}

--- a/AnalyticsApp/AnalyticsAppTests/AnalyticsAppTests.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AnalyticsAppTests.swift
@@ -1,0 +1,16 @@
+//
+//  AnalyticsAppTests.swift
+//  AnalyticsAppTests
+//
+//  Created by Satheesh Kannan on 20/01/25.
+//
+
+import Testing
+
+struct AnalyticsAppTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/AnalyticsApp/AnalyticsAppTests/AppTestingHelper.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AppTestingHelper.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Analytics
 
+// MARK: - MockEvent
 class MockEvent: Message {
     var anonymousId: String?
     var channel: String?

--- a/AnalyticsApp/AnalyticsAppTests/AppTestingHelper.swift
+++ b/AnalyticsApp/AnalyticsAppTests/AppTestingHelper.swift
@@ -1,0 +1,39 @@
+//
+//  AppTestingHelper.swift
+//  AnalyticsAppTests
+//
+//  Created by Satheesh Kannan on 20/01/25.
+//
+
+import Foundation
+import Analytics
+
+class MockEvent: Message {
+    var anonymousId: String?
+    var channel: String?
+    var integrations: [String : Bool]?
+    var sentAt: String?
+    var context: [String : Analytics.AnyCodable]?
+    var traits: Analytics.CodableCollection?
+    var type: Analytics.EventType = .track
+    var messageId: String = UUID().uuidString
+    var originalTimeStamp: String = Date().description
+}
+
+
+// MARK: - Given_When_Then
+func given(_ description: String = "", closure: () -> Void) {
+    if !description.isEmpty { print("Given \(description)") }
+    closure()
+}
+
+func when(_ description: String = "", closure: () -> Void) {
+    if !description.isEmpty { print("When \(description)") }
+    closure()
+}
+
+func then(_ description: String = "", closure: () -> Void) {
+    if !description.isEmpty { print("Then \(description)") }
+    closure()
+}
+


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

In this PR, we are introducing s a custom plugin, `AdvertisingIdPlugin`, to retrieve and attach the Advertising ID and Ad Tracking preferences to event messages within the `RudderStack` analytics context. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->
- `AdvertisingIdPlugin`: Plugin that retrieves the IDFA value and add that to event context.
- `AnalyticsManager`: An existing class is moved to separate file for betterment. 

The following fields will be add to `context.device`, if ad tracking is enabled.

`advertisingId`: Device Advertising ID when available and tracking is enabled.
`adTrackingEnabled`: Boolean indicating if ad tracking is permitted on the device.

Note:
To enable ad tracking, `NSUserTrackingUsageDescription` value should be added to the project's plist.


## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Run the app in any iOS device
- Allow app to track, when alert shows
- Check `context.device` part of event JSON

## Sample JSON
```JSON
{
  "anonymousId": "51AC9943-A1E7-4E45-8ED0-14988244BF0B",
  "channel": "mobile",
  "context": {
    "SK": {
      "Key1": "Value1"
    },
    "app": {
      "build": "1",
      "name": "AnalyticsApp",
      "namespace": "com.ska.AnalyticsApp",
      "version": "1.0"
    },
    "device": {
      "adTrackingEnabled": true,
      "advertisingId": "E58F6A07-1D3E-4257-953B-21A9F7E0F0AE",
      "id": "27485F73-6F6B-44B0-9DBD-34FDD331CACF",
      "manufacturer": "Apple",
      "model": "iPhone12,1",
      "name": "iPhone",
      "type": "iOS"
    },
    "library": {
      "name": "rudder-ios-library",
      "version": "1.31.0"
    },
    "locale": "en-IN",
    "network": {
      "bluetooth": true,
      "cellular": false,
      "wifi": true
    },
    "os": {
      "name": "iOS",
      "version": "18.2.1"
    },
    "screen": {
      "density": 2,
      "height": 896,
      "width": 414
    },
    "timezone": "Asia/Kolkata"
  },
  "event": "Analytics Screen",
  "integrations": {
    "All": true,
    "Facebook": false
  },
  "messageId": "7AE53A7A-4243-43DF-8FC9-1A4CB4CDF1E8",
  "originalTimeStamp": "2025-01-20T17:50:15.687Z",
  "properties": {
    "key": "value",
    "name": "Analytics Screen"
  },
  "sentAt": "2025-01-20T17:50:18.101Z",
  "type": "screen"
}
```

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->
![IMG_0037](https://github.com/user-attachments/assets/d986e1a9-505b-4267-a439-e5a2b0e62483)
