### PR TITLE
fix: prevent triggering duplicate Application Opened events

### DIFF
--- a/Analytics/Analytics/Helpers/Extensions.swift
+++ b/Analytics/Analytics/Helpers/Extensions.swift
@@ -8,6 +8,10 @@
 import Foundation
 import zlib
 
+#if os(iOS)
+import UIKit
+#endif
+
 // MARK: - String
 extension String {
     static let empty: String = ""
@@ -365,3 +369,30 @@ extension Data {
     // swiftlint:enable force_unwrapping
     // swiftlint:enable no_magic_numbers
 }
+
+#if os(iOS)
+extension ProcessInfo {
+    static var isSwiftUIiOSApp: Bool {
+        // Strategy 1: Detect internal SwiftUI delegate classes
+        let swiftUIInternalClassNames = [
+            "_TtC7SwiftUI19_UIApplicationSceneDelegate",
+            "_TtC7SwiftUI22_UIApplicationDelegate"
+        ]
+
+        for className in swiftUIInternalClassNames where NSClassFromString(className) != nil {
+            return true
+        }
+
+        // Strategy 2: Look for Hosting Controllers in window hierarchy
+        for case let windowScene as UIWindowScene in UIApplication.shared.connectedScenes {
+            for window in windowScene.windows where window.isKeyWindow {
+                if let rootVC = window.rootViewController,
+                   String(describing: type(of: rootVC)).contains("UIHostingController") {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+#endif

--- a/Analytics/Analytics/Helpers/Extensions.swift
+++ b/Analytics/Analytics/Helpers/Extensions.swift
@@ -373,17 +373,6 @@ extension Data {
 #if os(iOS)
 extension ProcessInfo {
     static var isSwiftUIiOSApp: Bool {
-        // Strategy 1: Detect internal SwiftUI delegate classes
-        let swiftUIInternalClassNames = [
-            "_TtC7SwiftUI19_UIApplicationSceneDelegate",
-            "_TtC7SwiftUI22_UIApplicationDelegate"
-        ]
-
-        for className in swiftUIInternalClassNames where NSClassFromString(className) != nil {
-            return true
-        }
-
-        // Strategy 2: Look for Hosting Controllers in window hierarchy
         for case let windowScene as UIWindowScene in UIApplication.shared.connectedScenes {
             for window in windowScene.windows where window.isKeyWindow {
                 if let rootVC = window.rootViewController,

--- a/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
+++ b/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
@@ -18,7 +18,6 @@ final class LifecycleTrackingPlugin: Plugin {
     var appVersion: AppVersion?
     
     @Synchronized private var isFirstLaunch = true
-    @Synchronized private var firstForeGround = true
     
     func setup(analytics: AnalyticsClient) {
         self.analytics = analytics
@@ -41,14 +40,6 @@ final class LifecycleTrackingPlugin: Plugin {
 
 extension LifecycleTrackingPlugin: LifecycleEventListener {
     func onBecomeActive() {
-        // Ignore the first foreground event on watchOS and macOS to prevent duplicate tracking
-#if os(watchOS) || os(macOS)
-        if firstForeGround {
-            firstForeGround = false
-            return
-        }
-#endif
-        
         var properties: [String: Any] = [:]
         if isFirstLaunch {
             properties["version"] = appVersion?.currentVersionName
@@ -81,7 +72,11 @@ extension LifecycleTrackingPlugin {
                 "previous_build": appVersion.previousBuild
             ])
         }
+
+        // Ignore the first foreground event on watchOS and macOS to prevent duplicate tracking
+#if !os(watchOS) && !os(macOS)
         self.onBecomeActive()
+#endif
     }
 }
 

--- a/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
+++ b/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
@@ -73,9 +73,8 @@ extension LifecycleTrackingPlugin {
             ])
         }
 
-#if !os(watchOS) && !os(macOS)
-        // Ignore the first foreground event on watchOS and macOS to prevent duplicate tracking
-        self.onBecomeActive()
+#if os(iOS)
+        if ProcessInfo.isSwiftUIiOSApp { self.onBecomeActive() }
 #endif
     }
 }

--- a/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
+++ b/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
@@ -64,7 +64,7 @@ extension LifecycleTrackingPlugin {
                 "version": appVersion.currentVersionName ?? "",
                 "build": appVersion.currentBuild
             ])
-        } else if appVersion.previousBuild != appVersion.currentBuild {
+        } else if appVersion.currentVersionName != appVersion.previousVersionName {
             self.analytics?.track(name: LifecycleEvent.applicationUpdated.rawValue, properties: [
                 "version": appVersion.currentVersionName ?? "",
                 "build": appVersion.currentBuild,

--- a/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
+++ b/Analytics/Analytics/Plugins/LifecycleTrackingPlugin.swift
@@ -73,8 +73,8 @@ extension LifecycleTrackingPlugin {
             ])
         }
 
-        // Ignore the first foreground event on watchOS and macOS to prevent duplicate tracking
 #if !os(watchOS) && !os(macOS)
+        // Ignore the first foreground event on watchOS and macOS to prevent duplicate tracking
         self.onBecomeActive()
 #endif
     }

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -39,7 +39,8 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         print("Then the plugin should track installation event")
         let eventNames = await fetchTrackedEventNames()
         guard !eventNames.isEmpty else { XCTFail("No events recorded"); return }
-        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue)
+        
+        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue && eventNames.last == LifecycleEvent.applicationOpened.rawValue)
     }
     
     func test_application_opened_event() async {

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -95,24 +95,6 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         XCTAssert(eventNames.contains(LifecycleEvent.applicationUpdated.rawValue))
     }
     
-    func test_trackAppInstallAndUpdateEvents_does_not_fire_opened_event_on_watchOS_macOS() async {
-        analyticsMock?.configuration.trackApplicationLifecycleEvents = true
-        guard let analyticsMock else { XCTFail("No disk client"); return }
-        plugin.setup(analytics: analyticsMock)
-        
-        // Simulate app install/update events
-        plugin.trackAppInstallAndUpdateEvents()
-        
-        let eventNames = await fetchTrackedEventNames()
-        guard !eventNames.isEmpty else { XCTFail("No events recorded"); return }
-        
-        #if os(watchOS) || os(macOS)
-        // On watchOS and macOS, Application Opened should NOT be tracked automatically
-        XCTAssertFalse(eventNames.contains(LifecycleEvent.applicationOpened.rawValue),
-                      "Application Opened event should NOT be tracked automatically on watchOS and macOS to prevent duplicate tracking")
-        #endif
-    }
-    
     private func fetchTrackedEventNames() async -> [String] {
         try? await Task.sleep(nanoseconds: 300_000_000)
         guard let analyticsMock else { return [] }

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -40,7 +40,7 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         let eventNames = await fetchTrackedEventNames()
         guard !eventNames.isEmpty else { XCTFail("No events recorded"); return }
         
-        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue && eventNames.last == LifecycleEvent.applicationOpened.rawValue)
+        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue)
     }
     
     func test_application_opened_event() async {

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -39,8 +39,7 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         print("Then the plugin should track installation event")
         let eventNames = await fetchTrackedEventNames()
         guard !eventNames.isEmpty else { XCTFail("No events recorded"); return }
-        
-        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue && eventNames.last == LifecycleEvent.applicationOpened.rawValue)
+        XCTAssert(eventNames.first == LifecycleEvent.applicationInstalled.rawValue)
     }
     
     func test_application_opened_event() async {

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -111,10 +111,6 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         // On watchOS and macOS, Application Opened should NOT be tracked automatically
         XCTAssertFalse(eventNames.contains(LifecycleEvent.applicationOpened.rawValue),
                       "Application Opened event should NOT be tracked automatically on watchOS and macOS to prevent duplicate tracking")
-        #else
-        // On other platforms, Application Opened should be tracked automatically
-        XCTAssert(eventNames.contains(LifecycleEvent.applicationOpened.rawValue),
-                 "Application Opened event should be tracked automatically on iOS/tvOS platforms")
         #endif
     }
     

--- a/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Analytics/AnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -101,21 +101,11 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         guard let analyticsMock else { XCTFail("No disk client"); return }
         plugin.setup(analytics: analyticsMock)
         
-        // Simulate an app update scenario to trigger the method
-        plugin.appVersion = AppVersion(
-            currentVersionName: "2.0",
-            currentBuild: 20,
-            previousVersionName: "1.0",
-            previousBuild: 10
-        )
+        // Simulate app install/update events
         plugin.trackAppInstallAndUpdateEvents()
         
         let eventNames = await fetchTrackedEventNames()
         guard !eventNames.isEmpty else { XCTFail("No events recorded"); return }
-        
-        // Verify that Application Updated is tracked
-        XCTAssert(eventNames.contains(LifecycleEvent.applicationUpdated.rawValue), 
-                 "Application Updated event should be tracked")
         
         #if os(watchOS) || os(macOS)
         // On watchOS and macOS, Application Opened should NOT be tracked automatically


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- Fixed tracking of duplicate `Application Opened` events on the first app launch.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- We conducted a series of tests to understand the behaviour of lifecycle notifications triggered by the Apple OS across different platforms.
- Our findings indicate that for iOS SwiftUI applications, the "Application Opened" event notification is not triggered on the initial app launch. Consequently, we must manually trigger this event in that specific scenario.
- In all other tested cases—including macOS, tvOS, and watchOS applications built with both SwiftUI and UIKit—the notification is triggered correctly as expected.
- We've implemented a pre-processor check to manually trigger the first `Application Opened` event only on the iOS-SwiftUI based app.

NOTE: Unit test will be added in future when we align on the proper way to write platform-specific unit tests.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Fix: Run the app on all the different platform, only a single Application Opened event will be fired on the first app launch and in that event properties we will have `"from_background": false`.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
