### PR TITLE
feat: call the reset api when userId changes in the identify event

### DIFF
--- a/Analytics/Analytics/Base/AnalyticsClient.swift
+++ b/Analytics/Analytics/Base/AnalyticsClient.swift
@@ -161,6 +161,12 @@ extension AnalyticsClient {
     public func identify(userId: String? = nil, traits: RudderTraits? = nil, options: RudderOption? = nil) {
         guard self.isAnalyticsActive else { return }
         
+        if let currentUserId = self.userId, !currentUserId.isEmpty,
+           let newUserId = userId, !newUserId.isEmpty,
+           currentUserId != newUserId {
+            reset()
+        }
+        
         self.userIdentityState.dispatch(action: SetUserIdAndTraitsAction(userId: userId ?? "", traits: traits ?? RudderTraits(), storage: self.storage))
         self.userIdentityState.state.value.storeUserIdAndTraits(self.storage)
         

--- a/Analytics/AnalyticsTests/AnalyticsTests.swift
+++ b/Analytics/AnalyticsTests/AnalyticsTests.swift
@@ -251,30 +251,20 @@ extension AnalyticsTests {
         }
     }
     
-    func test_identify_noResetWhenUserIdIsEmpty() async {
+    func test_identify_noResetWhenUserIdIsEmptyOrNotPassed() async {
         given("Analytics client with an identified user") {
             guard let client = analytics_disk else { return XCTFail("No disk client") }
             
             client.identify(userId: "initial_user", traits: ["name": "Initial User"])
+            let initialAnonymousId = client.anonymousId
             
             when("identifying with empty userId") {
-                let initialAnonymousId = client.anonymousId
                 client.identify(userId: "", traits: ["name": "Empty User"])
                 
                 then("should not reset (anonymousId remains the same)") {
                     XCTAssertEqual(initialAnonymousId, client.anonymousId, "Anonymous ID should not change when identifying with empty userId")
                 }
             }
-        }
-    }
-    
-    func test_identify_resetWhenOnlyTraitsIsPassed() async {
-        given("Analytics client with an existing identified user") {
-            guard let client = analytics_disk else { return XCTFail("No disk client") }
-            
-            client.identify(userId: "existing_user", traits: ["name": "Existing User"])
-            
-            let initialAnonymousId = client.anonymousId
             
             when("identifying with only traits") {
                 client.identify(traits: ["name": "Anonymous User"])

--- a/AnalyticsApp/AnalyticsApp/ContentView.swift
+++ b/AnalyticsApp/AnalyticsApp/ContentView.swift
@@ -57,11 +57,21 @@ struct ContentView: View {
                 }
             }
             
-            CustomButton(title: "Read AnonymousId") {
-                if let anonymousId = AnalyticsManager.shared.anonymousId {
-                    LoggerAnalytics.debug(log: "Current Anonymous Id: \(anonymousId)")
-                } else {
-                    LoggerAnalytics.debug(log: "Current Anonymous Id: nil")
+            HStack {
+                CustomButton(title: "Read AnonymousId") {
+                    if let anonymousId = AnalyticsManager.shared.anonymousId {
+                        LoggerAnalytics.debug(log: "Current Anonymous Id: \(anonymousId)")
+                    } else {
+                        LoggerAnalytics.debug(log: "Current Anonymous Id: nil")
+                    }
+                }
+                
+                CustomButton(title: "Read UserId") {
+                    if let userId = AnalyticsManager.shared.userId {
+                        LoggerAnalytics.debug(log: "Current User Id: \(userId)")
+                    } else {
+                        LoggerAnalytics.debug(log: "Current User Id: nil")
+                    }
                 }
             }
             

--- a/AnalyticsApp/AnalyticsApp/Managers/AnalyticsManager.swift
+++ b/AnalyticsApp/AnalyticsApp/Managers/AnalyticsManager.swift
@@ -32,7 +32,7 @@ class AnalyticsManager {
 
 // MARK: - Rudder methods
 extension AnalyticsManager {
-    func identify(userId: String, traits: RudderTraits? = nil, options: RudderOption? = nil) {
+    func identify(userId: String? = nil, traits: RudderTraits? = nil, options: RudderOption? = nil) {
         self.analytics?.identify(userId: userId, traits: traits, options: options)
     }
     
@@ -78,6 +78,10 @@ extension AnalyticsManager {
     
     var sessionId: UInt64? {
         return self.analytics?.sessionId
+    }
+    
+    var userId: String? {
+        return self.analytics?.userId
     }
     
     func openURL(_ url: URL, options: [String: Any]? = nil) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- Added a new behaviour to call RESET when `userId` changes in different identify event.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- A `reset` call will be triggered, when the following conditions are met, on the identify event:
    - The previous userId is not nil/empty.
    - Current userId (passed in the second identify event) is not nil/empty.
    - Both are different.
- Added new test cases to cover the new changes.
- In sample app:
    - In `ContentView`: Added a button to read the `userId`.
    - In `AnalyticsManager`: Added an option to make identify event with only traits.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. First make an identify event with userId-1: `instance.identify(userId_1)`.
    - After that: In both the following cases, you can note that `anonymousId` and `sessionId` will remain the same.
        - Make another identify event with only traits: `instance.identify(traits)`.
        - Make another identify event with empty userId: `instance.identify("", traits)`.
        - Make another identify event with same userId: `instance.identify(userId_1, traits)`.
    - After that: On the following call, you can note that new `anonymousId` and `sessionId` values are generated.
        - Make another identify event with a different userId: `instance.identify(userId_2)`.
2. Make the first identify event with only traits: `instance.identify(traits)` - you can note that `anonymousId` and `sessionId` will remain the same.

AnonymousId and sessionId should remain the same:
```
Identify(traits)
Identify(user1) + Identify(user1)
Identify(user1) + Identify("", traits)
Identify(user1) + Identify(traits)
```

AnonymousId and sessionId should change:
```
Identify(user1) + Identify(user2)
```

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

- Previously, even if the above conditions are met a new anonymousId or sessionId are not generated. Now, new values will be generated.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

NOTE: There is an issue with the identify implementation, i.e., `userId` and `traits` are getting cleared even when the `userId` is the same. We will fix this in future. Therefore, I've purposefully skipped adding test cases for that.