### PR TITLE
fix: resolve failing test cases in CountFlushPolicy tests

### DIFF
--- a/Tests/RudderStackAnalyticsTests/FlushPolicyModuleTests.swift
+++ b/Tests/RudderStackAnalyticsTests/FlushPolicyModuleTests.swift
@@ -12,7 +12,7 @@ final class CountFlushPolicyTests: XCTestCase {
     
     func test_defaultShouldFlush() {
         given("CountFlushPolicy with a flush count of 5") {
-            let policy = CountFlushPolicy(flushCount: 5)
+            let policy = CountFlushPolicy(flushAt: 5)
             
             then("initially returns false..") {
                 XCTAssertFalse(policy.shouldFlush())
@@ -22,7 +22,7 @@ final class CountFlushPolicyTests: XCTestCase {
     
     func test_shouldFlushAfterReachingFlushCount() {
         given("CountFlushPolicy with a flush count of 5") {
-            let policy = CountFlushPolicy(flushCount: 5)
+            let policy = CountFlushPolicy(flushAt: 5)
             
             when("flush count not reached the limit..") {
                 for _ in 1...4 {
@@ -46,7 +46,7 @@ final class CountFlushPolicyTests: XCTestCase {
     
     func test_resetCount() {
         given("CountFlushPolicy with a flush count of 5") {
-            let policy = CountFlushPolicy(flushCount: 5)
+            let policy = CountFlushPolicy(flushAt: 5)
             
             when("flush count reached the limit..") {
                 for _ in 1...5 {
@@ -87,7 +87,7 @@ final class CountFlushPolicyTests: XCTestCase {
             }
             
             when("pass the minimum flush count...") {
-                let policy = CountFlushPolicy(flushCount: minimum)
+                let policy = CountFlushPolicy(flushAt: minimum)
                 
                 for _ in 1..<minimum {
                     policy.updateEventCount()
@@ -107,7 +107,7 @@ final class CountFlushPolicyTests: XCTestCase {
             }
             
             when("pass the maximum flush count...") {
-                let policy = CountFlushPolicy(flushCount: maximum)
+                let policy = CountFlushPolicy(flushAt: maximum)
                 
                 for _ in 1..<maximum {
                     policy.updateEventCount()


### PR DESCRIPTION
## Description
This pull request fixes a test compilation issue in `FlushPolicyModuleTests.swift` by updating the parameter name from the deprecated `flushCount` to the correct `flushAt` in all `CountFlushPolicy` initializations. This ensures the test suite is compatible with the current API and can compile and run successfully.

The change aligns the test code with the actual `CountFlushPolicy` implementation, which uses `flushAt` as the parameter name in its initializer.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Updated all `CountFlushPolicy` constructor calls in test methods to use the correct parameter name `flushAt` instead of the outdated `flushCount`
- No changes to test logic or behavior - only parameter name corrections
- Ensures compatibility with the current `CountFlushPolicy` API that expects `flushAt: Int` parameter

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- **Build the test target**: Ensure the project compiles without errors
- **Verify test behavior**: Confirm that the tests validate the correct flush behavior:
   - Tests should pass when event count reaches the specified threshold
   - Tests should fail when event count is below the threshold

## Breaking Changes
None. This is a test-only change that fixes compatibility with the existing `CountFlushPolicy` API without affecting any production code or public interfaces.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This change affects test code only, no UI components involved.

## Additional Context
The `CountFlushPolicy` class implementation uses the parameter name `flushAt` in its public initializer:

```swift
public init(flushAt: Int = Constants.flushEventCount.default)
```

The tests were using an outdated parameter name `flushCount` which would cause compilation errors. This change ensures the test suite stays in sync with the actual API implementation and can continue to provide reliable test coverage for the flush policy functionality.

This fix is part of maintaining test code quality and ensuring the CI/CD pipeline can execute tests successfully.
