### PR TITLE
feat: update visibility of Event subclasses to public

### DIFF
--- a/Examples/ObjCExample/ObjCExample.xcodeproj/project.pbxproj
+++ b/Examples/ObjCExample/ObjCExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5328B8752E3B7BEA0051A202 /* EventFilteringPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8732E3B7BEA0051A202 /* EventFilteringPlugin.m */; };
 		535BB4C82E048E8200E1DAB0 /* CustomOptionPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 535BB4B12E048E8200E1DAB0 /* CustomOptionPlugin.m */; };
 		535BB4C92E048E8200E1DAB0 /* ObjCCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 535BB4B72E048E8200E1DAB0 /* ObjCCompat.m */; };
 		535BB4CA2E048E8200E1DAB0 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 535BB4C22E048E8200E1DAB0 /* ViewController.m */; };
@@ -39,6 +40,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5328B8722E3B7BEA0051A202 /* EventFilteringPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EventFilteringPlugin.h; sourceTree = "<group>"; };
+		5328B8732E3B7BEA0051A202 /* EventFilteringPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EventFilteringPlugin.m; sourceTree = "<group>"; };
 		5352C76D2DCBCB390022B105 /* ObjCExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		535BB4A52E048E8200E1DAB0 /* AnalyticsManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnalyticsManager.h; sourceTree = "<group>"; };
 		535BB4A62E048E8200E1DAB0 /* AnalyticsManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AnalyticsManager.m; sourceTree = "<group>"; };
@@ -78,6 +81,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5328B8742E3B7BEA0051A202 /* EventFilteringPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				5328B8722E3B7BEA0051A202 /* EventFilteringPlugin.h */,
+				5328B8732E3B7BEA0051A202 /* EventFilteringPlugin.m */,
+			);
+			path = EventFilteringPlugin;
+			sourceTree = "<group>";
+		};
 		5352C7642DCBCB390022B105 = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +156,7 @@
 		535BB4B52E048E8200E1DAB0 /* CustomPlugins */ = {
 			isa = PBXGroup;
 			children = (
+				5328B8742E3B7BEA0051A202 /* EventFilteringPlugin */,
 				535BB4BB2E048E8200E1DAB0 /* SetPushTokenPlugin */,
 				535BB4B22E048E8200E1DAB0 /* CustomOptionPlugin */,
 				535BB4F52E04907200E1DAB0 /* SetAnonymousIdPlugin */,
@@ -296,6 +309,7 @@
 				535BB4CD2E048E8200E1DAB0 /* main.m in Sources */,
 				535BB4CE2E048E8200E1DAB0 /* SceneDelegate.m in Sources */,
 				535BB4CF2E048E8200E1DAB0 /* SetAnonymousIdPlugin.m in Sources */,
+				5328B8752E3B7BEA0051A202 /* EventFilteringPlugin.m in Sources */,
 				535BB4D02E048E8200E1DAB0 /* SetPushTokenPlugin.m in Sources */,
 				535BB4D12E048E8200E1DAB0 /* CustomLogger.m in Sources */,
 			);

--- a/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
+++ b/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
@@ -8,6 +8,7 @@
 #import "AnalyticsManager.h"
 #import "CustomLogger.h"
 #import "CustomOptionPlugin.h"
+#import "EventFilteringPlugin.h"
 
 @interface AnalyticsManager()
 
@@ -28,8 +29,8 @@
 
 - (void)initializeAnalyticsSDK {
 
-    NSString *writeKey = @"sample-write-key";
-    NSString *dataPlaneUrl = @"https://data-plane.analytics.com";
+    NSString *writeKey = @"2vPgTJJHX8Z1fpU8DWjDGlmyJpF";
+    NSString *dataPlaneUrl = @"https://rudderstacfbtt.dataplane.rudderstack.com";
     
     RSSConfigurationBuilder *builder = [[RSSConfigurationBuilder alloc] initWithWriteKey:writeKey dataPlaneUrl:dataPlaneUrl];
     [builder setGzipEnabled: YES];
@@ -57,6 +58,10 @@
     // Adding custom plugin..
     CustomOptionPlugin *plugin = [[CustomOptionPlugin alloc] initWithOption:[optionBuilder build]];
     [self.client addPlugin:plugin];
+    
+    EventFilteringPlugin *pp = [[EventFilteringPlugin alloc] init];
+    [self.client addPlugin:pp];
+
 }
 
 - (void)identify:(NSString * _Nullable)userId traits:(NSDictionary<NSString *,id> * _Nullable)traits options:(RSSOption* _Nullable)option {

--- a/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
+++ b/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
@@ -8,7 +8,6 @@
 #import "AnalyticsManager.h"
 #import "CustomLogger.h"
 #import "CustomOptionPlugin.h"
-#import "EventFilteringPlugin.h"
 
 @interface AnalyticsManager()
 
@@ -29,8 +28,8 @@
 
 - (void)initializeAnalyticsSDK {
 
-    NSString *writeKey = @"2vPgTJJHX8Z1fpU8DWjDGlmyJpF";
-    NSString *dataPlaneUrl = @"https://rudderstacfbtt.dataplane.rudderstack.com";
+    NSString *writeKey = @"sample-write-key";
+    NSString *dataPlaneUrl = @"https://data-plane.analytics.com";
     
     RSSConfigurationBuilder *builder = [[RSSConfigurationBuilder alloc] initWithWriteKey:writeKey dataPlaneUrl:dataPlaneUrl];
     [builder setGzipEnabled: YES];
@@ -58,10 +57,6 @@
     // Adding custom plugin..
     CustomOptionPlugin *plugin = [[CustomOptionPlugin alloc] initWithOption:[optionBuilder build]];
     [self.client addPlugin:plugin];
-    
-    EventFilteringPlugin *pp = [[EventFilteringPlugin alloc] init];
-    [self.client addPlugin:pp];
-
 }
 
 - (void)identify:(NSString * _Nullable)userId traits:(NSDictionary<NSString *,id> * _Nullable)traits options:(RSSOption* _Nullable)option {

--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
@@ -1,0 +1,19 @@
+//
+//  EventFilteringPlugin.h
+//  ObjCExampleApp
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+#import <Foundation/Foundation.h>
+@import RudderStackAnalytics;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EventFilteringPlugin : NSObject<RSSPlugin>
+
+- (instancetype)init;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
@@ -10,8 +10,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ A plugin that filters out specific events from being processed by the analytics pipeline.
+ 
+ By default, this plugin filters out "Application Opened" and "Application Backgrounded" events.
+ This is useful for reducing noise in analytics data by excluding automated lifecycle events
+ that may not be relevant for your specific use case.
+ 
+ **Note**: Filtered events are completely removed from the processing pipeline and will not be sent to any destinations.
+ 
+ Set this plugin just after the SDK initialization to start filtering events:
+ ```objective-c
+ [analytics add:[[EventFilteringPlugin alloc] init]];
+ ```
+ 
+ The plugin logs when events are filtered for debugging purposes.
+ */
 @interface EventFilteringPlugin : NSObject<RSSPlugin>
 
+/**
+ Initializes the EventFilteringPlugin with default filtering rules.
+  
+ @return An initialized EventFilteringPlugin instance
+ */
 - (instancetype)init;
 
 @end

--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
@@ -7,9 +7,14 @@
 
 #import "EventFilteringPlugin.h"
 
+#pragma mark - EventFilteringPlugin
+
 @interface EventFilteringPlugin()
 
+/// Reference to the analytics client
 @property(nonatomic, retain) RSSAnalytics *client;
+
+/// Array of event names that should be filtered out
 @property(nonatomic, retain) NSMutableArray *eventsToFilter;
 
 @end
@@ -17,10 +22,11 @@
 @implementation EventFilteringPlugin
 @synthesize pluginType;
 
--(instancetype)init
-{
+- (instancetype)init {
     self = [super init];
-    if (self) {}
+    if (self) {
+        // Initialize with default events to filter
+    }
     return self;
 }
 
@@ -30,22 +36,44 @@
 
 - (void)setup:(RSSAnalytics * _Nonnull)analytics {
     self.client = analytics;
+    // Set up default events to filter - Application lifecycle events that are often noise
     self.eventsToFilter = [NSMutableArray arrayWithArray: @[@"Application Opened", @"Application Backgrounded"]];
 }
 
-- (RSSEvent *)intercept:(RSSEvent *)event {
+/**
+ Intercepts events and filters out unwanted events based on the configured filter list.
+ 
+ @param event The event to potentially filter
+ @return The original event if it should pass through, or nil if it should be filtered out
+ */
+- (RSSEvent * _Nullable)intercept:(RSSEvent * _Nonnull)event {
     if ([event isKindOfClass:[RSSTrackEvent class]]) {
         RSSTrackEvent *trackEvent = (RSSTrackEvent *)event;
-        if ([self.eventsToFilter containsObject: trackEvent.eventName]) {
+        if ([self shouldFilterEvent:trackEvent]) {
             [RSSLoggerAnalytics verbose:[NSString stringWithFormat:@"EventFilteringPlugin: Event \"%@\" is filtered out.", trackEvent.eventName]];
-            return nil;
+            return nil; // Filter out this event
         }
     }
-    return event;
+    return event; // Allow event to pass through
 }
 
+/**
+ Determines whether a track event should be filtered based on its event name.
+ 
+ @param trackEvent The track event to evaluate
+ @return YES if the event should be filtered out, NO if it should pass through
+ */
+- (BOOL)shouldFilterEvent:(RSSTrackEvent *)trackEvent {
+    return [self.eventsToFilter containsObject:trackEvent.eventName];
+}
+
+/**
+ Cleans up resources when the plugin is being removed or the analytics client is shutting down.
+ */
 - (void)teardown {
     [self.eventsToFilter removeAllObjects];
+    self.eventsToFilter = nil;
+    self.client = nil;
 }
 
 @end

--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
@@ -1,0 +1,51 @@
+//
+//  EventFilteringPlugin.m
+//  ObjCExampleApp
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+#import "EventFilteringPlugin.h"
+
+@interface EventFilteringPlugin()
+
+@property(nonatomic, retain) RSSAnalytics *client;
+@property(nonatomic, retain) NSMutableArray *eventsToFilter;
+
+@end
+
+@implementation EventFilteringPlugin
+@synthesize pluginType;
+
+-(instancetype)init
+{
+    self = [super init];
+    if (self) {}
+    return self;
+}
+
+- (RSSPluginType)pluginType {
+    return RSSPluginTypeOnProcess;
+}
+
+- (void)setup:(RSSAnalytics * _Nonnull)analytics {
+    self.client = analytics;
+    self.eventsToFilter = [NSMutableArray arrayWithArray: @[@"Application Opened", @"Application Backgrounded"]];
+}
+
+- (RSSEvent *)intercept:(RSSEvent *)event {
+    if ([event isKindOfClass:[RSSTrackEvent class]]) {
+        RSSTrackEvent *trackEvent = (RSSTrackEvent *)event;
+        if ([self.eventsToFilter containsObject: trackEvent.eventName]) {
+            [RSSLoggerAnalytics verbose:[NSString stringWithFormat:@"EventFilteringPlugin: Event \"%@\" is filtered out.", trackEvent.eventName]];
+            return nil;
+        }
+    }
+    return event;
+}
+
+- (void)teardown {
+    [self.eventsToFilter removeAllObjects];
+}
+
+@end

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5328B86C2E3B48820051A202 /* EventFilteringPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */; };
 		535BB3E22E04642400E1DAB0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 535BB3D92E04642400E1DAB0 /* Preview Assets.xcassets */; };
 		535BB3E42E04642400E1DAB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 535BB3DB2E04642400E1DAB0 /* Assets.xcassets */; };
 		535BB3E52E04642400E1DAB0 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3E02E04642400E1DAB0 /* SwiftUIExampleApp.swift */; };
@@ -55,6 +56,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilteringPlugin.swift; sourceTree = "<group>"; };
 		5351AA792C6BE9DE003C3C47 /* SwiftUIExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		535BB3D02E04642400E1DAB0 /* AdvertisingIdPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingIdPlugin.swift; sourceTree = "<group>"; };
 		535BB3D12E04642400E1DAB0 /* BluetoothInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothInfoPlugin.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				535BB3D22E04642400E1DAB0 /* OptionPlugin.swift */,
 				535BB3D32E04642400E1DAB0 /* SetAnonymousIdPlugin.swift */,
 				535BB3D42E04642400E1DAB0 /* SetPushTokenPlugin.swift */,
+				5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */,
 			);
 			path = CustomPlugins;
 			sourceTree = "<group>";
@@ -296,6 +299,7 @@
 				535BB3E92E04642400E1DAB0 /* SetAnonymousIdPlugin.swift in Sources */,
 				535BB3EA2E04642400E1DAB0 /* ContentView.swift in Sources */,
 				535BB3EB2E04642400E1DAB0 /* BluetoothInfoPlugin.swift in Sources */,
+				5328B86C2E3B48820051A202 /* EventFilteringPlugin.swift in Sources */,
 				535BB3EC2E04642400E1DAB0 /* OptionPlugin.swift in Sources */,
 				535BB3ED2E04642400E1DAB0 /* AdvertisingIdPlugin.swift in Sources */,
 				535BB3EE2E04642400E1DAB0 /* PermissionManager.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5328B86C2E3B48820051A202 /* EventFilteringPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */; };
+		5328B86E2E3B75B90051A202 /* EventFilteringPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B86D2E3B75B90051A202 /* EventFilteringPluginTests.swift */; };
 		535BB3E22E04642400E1DAB0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 535BB3D92E04642400E1DAB0 /* Preview Assets.xcassets */; };
 		535BB3E42E04642400E1DAB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 535BB3DB2E04642400E1DAB0 /* Assets.xcassets */; };
 		535BB3E52E04642400E1DAB0 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3E02E04642400E1DAB0 /* SwiftUIExampleApp.swift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilteringPlugin.swift; sourceTree = "<group>"; };
+		5328B86D2E3B75B90051A202 /* EventFilteringPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFilteringPluginTests.swift; sourceTree = "<group>"; };
 		5351AA792C6BE9DE003C3C47 /* SwiftUIExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		535BB3D02E04642400E1DAB0 /* AdvertisingIdPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingIdPlugin.swift; sourceTree = "<group>"; };
 		535BB3D12E04642400E1DAB0 /* BluetoothInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothInfoPlugin.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				535BB3EF2E04643900E1DAB0 /* AdvertisingIdPluginTests.swift */,
 				535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */,
 				535BB3F12E04643900E1DAB0 /* BluetoothInfoPluginTests.swift */,
+				5328B86D2E3B75B90051A202 /* EventFilteringPluginTests.swift */,
 				535BB3F22E04643900E1DAB0 /* OptionPluginTests.swift */,
 				535BB3F32E04643900E1DAB0 /* SetAnonymousIdPluginTests.swift */,
 				535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */,
@@ -312,6 +315,7 @@
 			files = (
 				535BB3F72E04643900E1DAB0 /* SetPushTokenPluginTests.swift in Sources */,
 				535BB3F82E04643900E1DAB0 /* AdvertisingIdPluginTests.swift in Sources */,
+				5328B86E2E3B75B90051A202 /* EventFilteringPluginTests.swift in Sources */,
 				535BB3F92E04643900E1DAB0 /* SetAnonymousIdPluginTests.swift in Sources */,
 				535BB3FA2E04643900E1DAB0 /* OptionPluginTests.swift in Sources */,
 				535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
@@ -38,7 +38,7 @@ final class EventFilteringPlugin: Plugin {
      - Returns: The original event if it should be processed, or nil if it should be filtered out
      */
     func intercept(event: any Event) -> (any Event)? {
-        if let trackEvent = event as? TrackEvent, eventsToFilter.contains(trackEvent.event) {
+        if let trackEvent = event as? TrackEvent, self.eventsToFilter.contains(trackEvent.event) {
             LoggerAnalytics.verbose(log: "EventFilteringPlugin: Event \"\(trackEvent.event)\" is filtered out.")
             return nil
         }
@@ -47,6 +47,6 @@ final class EventFilteringPlugin: Plugin {
     
     /** Called when the plugin is being removed or the analytics instance is being torn down */
     func teardown() {
-        eventsToFilter.removeAll()
+        self.eventsToFilter.removeAll()
     }
 }

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+import RudderStackAnalytics
+
+final class EventFilteringPlugin: Plugin {
+    var pluginType: PluginType = .onProcess
+    var analytics: Analytics?
+    
+    private var eventsToFilter = [String]()
+    
+    func setup(analytics: Analytics) {
+        self.analytics = analytics
+        self.eventsToFilter = ["Application Opened", "Application Backgrounded"]
+    }
+    
+    func intercept(event: any Event) -> (any Event)? {
+        if let trackEvent = event as? TrackEvent, eventsToFilter.contains(trackEvent.event) {
+            LoggerAnalytics.verbose(log: "EventFilteringPlugin: Event \"\(trackEvent.event)\" is filtered out.")
+            return nil
+        }
+        return event
+    }
+    
+    func teardown() {
+        eventsToFilter.removeAll()
+    }
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
@@ -8,17 +8,35 @@
 import Foundation
 import RudderStackAnalytics
 
+// MARK: - EventFilteringPlugin
+/**
+ This plugin filters out specific analytics events from being processed in the analytics pipeline. It allows you to prevent certain events from being tracked or sent to destinations.
+ 
+ ## Usage:
+ ```swift
+ // Create and add the plugin
+ let eventFilteringPlugin = EventFilteringPlugin()
+ analytics.add(plugin: eventFilteringPlugin)
+ ```
+*/
 final class EventFilteringPlugin: Plugin {
     var pluginType: PluginType = .onProcess
     var analytics: Analytics?
     
     private var eventsToFilter = [String]()
     
+    /** Called when the plugin is added to the analytics instance */
     func setup(analytics: Analytics) {
         self.analytics = analytics
         self.eventsToFilter = ["Application Opened", "Application Backgrounded"]
     }
     
+    /** 
+     Intercepts analytics events and filters out specified track events
+     
+     - Parameter event: The event to potentially filter
+     - Returns: The original event if it should be processed, or nil if it should be filtered out
+     */
     func intercept(event: any Event) -> (any Event)? {
         if let trackEvent = event as? TrackEvent, eventsToFilter.contains(trackEvent.event) {
             LoggerAnalytics.verbose(log: "EventFilteringPlugin: Event \"\(trackEvent.event)\" is filtered out.")
@@ -27,6 +45,7 @@ final class EventFilteringPlugin: Plugin {
         return event
     }
     
+    /** Called when the plugin is being removed or the analytics instance is being torn down */
     func teardown() {
         eventsToFilter.removeAll()
     }

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
@@ -1,0 +1,8 @@
+//
+//  EventFilteringPlugin.swift
+//  SwiftUIExampleApp
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+import Foundation

--- a/Examples/SwiftUIExample/SwiftUIExampleTests/EventFilteringPluginTests.swift
+++ b/Examples/SwiftUIExample/SwiftUIExampleTests/EventFilteringPluginTests.swift
@@ -1,0 +1,99 @@
+//
+//  EventFilteringPluginTests.swift
+//  SwiftUIExampleAppTests
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+import Testing
+import RudderStackAnalytics
+@testable import SwiftUIExampleApp
+
+struct EventFilteringPluginTests {
+    
+    private var testConfiguration: Configuration {
+        return Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
+    }
+    
+    @Test
+    func test_whenEventShouldBeFiltered() {
+        given("An EventFilteringPlugin initialized") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin()
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting a TrackEvent with a filtered event name") {
+                let filteredEvent = TrackEvent(event: "Application Opened")
+                let result = plugin.intercept(event: filteredEvent)
+                
+                then("The event should be filtered out (returns nil)") {
+                    #expect(result == nil)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenEventShouldNotBeFiltered() {
+        given("An EventFilteringPlugin initialized") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin()
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting a TrackEvent with a non-filtered event name") {
+                let allowedEvent = TrackEvent(event: "Product Purchased")
+                let result = plugin.intercept(event: allowedEvent)
+                
+                then("The event should pass through unchanged") {
+                    #expect(result != nil)
+                    guard let trackResult = result as? TrackEvent else {
+                        #expect(Bool(false), "Result should be a TrackEvent")
+                        return
+                    }
+                    #expect(trackResult.event == "Product Purchased")
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenMultipleEventsAreFiltered() {
+        given("An EventFilteringPlugin initialized") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin()
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting multiple events with different filtered event names") {
+                let filteredEvent1 = TrackEvent(event: "Application Opened")
+                let filteredEvent2 = TrackEvent(event: "Application Backgrounded")
+                
+                let result1 = plugin.intercept(event: filteredEvent1)
+                let result2 = plugin.intercept(event: filteredEvent2)
+                
+                then("Both events should be filtered out") {
+                    #expect(result1 == nil)
+                    #expect(result2 == nil)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenNonTrackEventIsIntercepted() {
+        given("An EventFilteringPlugin initialized") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin()
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting a non-TrackEvent (MockEvent)") {
+                let mockEvent = MockEvent()
+                let result = plugin.intercept(event: mockEvent)
+                
+                then("The event should pass through unchanged") {
+                    #expect(result != nil)
+                    #expect(result?.type == .track)
+                }
+            }
+        }
+    }
+}

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5328B8772E3B7E4D0051A202 /* ObjCUserIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */; };
 		5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */; };
+		5328B87B2E3C8B760051A202 /* ObjCScreenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */; };
 		532904EF2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */; };
 		532904F02E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */; };
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
@@ -144,6 +145,7 @@
 /* Begin PBXFileReference section */
 		5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCUserIdentity.swift; sourceTree = "<group>"; };
 		5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCTrackEvent.swift; sourceTree = "<group>"; };
+		5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCScreenEvent.swift; sourceTree = "<group>"; };
 		532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderStackAnalytics.xctestplan; sourceTree = "<group>"; };
 		532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftExampleApp.xctestplan; sourceTree = "<group>"; };
 		532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIExampleApp.xctestplan; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				53DEA5B32E03D05A00D6C371 /* ObjCSessionConfiguration.swift */,
 				5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */,
 				5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */,
+				5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -851,6 +854,7 @@
 				53DEA5EE2E03D05A00D6C371 /* SessionActions.swift in Sources */,
 				53DEA5EF2E03D05A00D6C371 /* LibraryInfoPlugin.swift in Sources */,
 				53DEA5F02E03D05A00D6C371 /* ObjCLogger.swift in Sources */,
+				5328B87B2E3C8B760051A202 /* ObjCScreenEvent.swift in Sources */,
 				53DEA5F12E03D05A00D6C371 /* SetUserIdAction.swift in Sources */,
 				53DEA5F22E03D05A00D6C371 /* SessionInfo.swift in Sources */,
 				53DEA5F32E03D05A00D6C371 /* LoggerAnalytics.swift in Sources */,

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5328B8772E3B7E4D0051A202 /* ObjCUserIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */; };
 		5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */; };
 		5328B87B2E3C8B760051A202 /* ObjCScreenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */; };
+		5328B87D2E3C8C240051A202 /* ObjCGroupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */; };
 		532904EF2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */; };
 		532904F02E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */; };
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
@@ -146,6 +147,7 @@
 		5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCUserIdentity.swift; sourceTree = "<group>"; };
 		5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCTrackEvent.swift; sourceTree = "<group>"; };
 		5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCScreenEvent.swift; sourceTree = "<group>"; };
+		5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCGroupEvent.swift; sourceTree = "<group>"; };
 		532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderStackAnalytics.xctestplan; sourceTree = "<group>"; };
 		532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftExampleApp.xctestplan; sourceTree = "<group>"; };
 		532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIExampleApp.xctestplan; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */,
 				5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */,
 				5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */,
+				5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -858,6 +861,7 @@
 				53DEA5F12E03D05A00D6C371 /* SetUserIdAction.swift in Sources */,
 				53DEA5F22E03D05A00D6C371 /* SessionInfo.swift in Sources */,
 				53DEA5F32E03D05A00D6C371 /* LoggerAnalytics.swift in Sources */,
+				5328B87D2E3C8C240051A202 /* ObjCGroupEvent.swift in Sources */,
 				53DEA5F42E03D05A00D6C371 /* SetUserIdAndTraitsAction.swift in Sources */,
 				53DEA5F52E03D05A00D6C371 /* FlushPolicy.swift in Sources */,
 				53DEA5F62E03D05A00D6C371 /* Storage.swift in Sources */,

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5328B87B2E3C8B760051A202 /* ObjCScreenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */; };
 		5328B87D2E3C8C240051A202 /* ObjCGroupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */; };
 		5328B87F2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */; };
+		5328B8812E3C939D0051A202 /* ObjCAliasEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8802E3C939D0051A202 /* ObjCAliasEvent.swift */; };
 		532904EF2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */; };
 		532904F02E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */; };
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
@@ -150,6 +151,7 @@
 		5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCScreenEvent.swift; sourceTree = "<group>"; };
 		5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCGroupEvent.swift; sourceTree = "<group>"; };
 		5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCIdentifyEvent.swift; sourceTree = "<group>"; };
+		5328B8802E3C939D0051A202 /* ObjCAliasEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCAliasEvent.swift; sourceTree = "<group>"; };
 		532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderStackAnalytics.xctestplan; sourceTree = "<group>"; };
 		532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftExampleApp.xctestplan; sourceTree = "<group>"; };
 		532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIExampleApp.xctestplan; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */,
 				5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */,
 				5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */,
+				5328B8802E3C939D0051A202 /* ObjCAliasEvent.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -913,6 +916,7 @@
 				53DEA61E2E03D05A00D6C371 /* ObjCLoggerAnalytics.swift in Sources */,
 				53DEA61F2E03D05A00D6C371 /* GroupEvent.swift in Sources */,
 				53DEA6202E03D05A00D6C371 /* LifecycleTrackingPlugin.swift in Sources */,
+				5328B8812E3C939D0051A202 /* ObjCAliasEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */; };
 		5328B87B2E3C8B760051A202 /* ObjCScreenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */; };
 		5328B87D2E3C8C240051A202 /* ObjCGroupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */; };
+		5328B87F2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */; };
 		532904EF2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */; };
 		532904F02E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */; };
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
@@ -148,6 +149,7 @@
 		5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCTrackEvent.swift; sourceTree = "<group>"; };
 		5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCScreenEvent.swift; sourceTree = "<group>"; };
 		5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCGroupEvent.swift; sourceTree = "<group>"; };
+		5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCIdentifyEvent.swift; sourceTree = "<group>"; };
 		532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderStackAnalytics.xctestplan; sourceTree = "<group>"; };
 		532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftExampleApp.xctestplan; sourceTree = "<group>"; };
 		532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIExampleApp.xctestplan; sourceTree = "<group>"; };
@@ -446,6 +448,7 @@
 				5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */,
 				5328B87A2E3C8B760051A202 /* ObjCScreenEvent.swift */,
 				5328B87C2E3C8C240051A202 /* ObjCGroupEvent.swift */,
+				5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -883,6 +886,7 @@
 				53DEA6062E03D05A00D6C371 /* TimeZoneInfoPlugin.swift in Sources */,
 				53DEA6072E03D05A00D6C371 /* SessionHandler.swift in Sources */,
 				53DEA6082E03D05A00D6C371 /* IdentifyEvent.swift in Sources */,
+				5328B87F2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift in Sources */,
 				53DEA6092E03D05A00D6C371 /* HttpClient.swift in Sources */,
 				53DEA60A2E03D05A00D6C371 /* ObjCConfiguration.swift in Sources */,
 				53DEA60B2E03D05A00D6C371 /* PluginChain.swift in Sources */,

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5328B8772E3B7E4D0051A202 /* ObjCUserIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */; };
+		5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */; };
 		532904EF2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */; };
 		532904F02E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */; };
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
@@ -140,6 +142,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCUserIdentity.swift; sourceTree = "<group>"; };
+		5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCTrackEvent.swift; sourceTree = "<group>"; };
 		532904EB2E05BBDE00C8EFE2 /* RudderStackAnalytics.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RudderStackAnalytics.xctestplan; sourceTree = "<group>"; };
 		532904EC2E05BBDE00C8EFE2 /* SwiftExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftExampleApp.xctestplan; sourceTree = "<group>"; };
 		532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUIExampleApp.xctestplan; sourceTree = "<group>"; };
@@ -434,6 +438,8 @@
 				53DEA5B12E03D05A00D6C371 /* ObjCOption.swift */,
 				53DEA5B22E03D05A00D6C371 /* ObjCPlugin.swift */,
 				53DEA5B32E03D05A00D6C371 /* ObjCSessionConfiguration.swift */,
+				5328B8762E3B7E4D0051A202 /* ObjCUserIdentity.swift */,
+				5328B8782E3B817B0051A202 /* ObjCTrackEvent.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -877,9 +883,11 @@
 				53DEA60E2E03D05A00D6C371 /* PluginInteractor.swift in Sources */,
 				53DEA60F2E03D05A00D6C371 /* NetworkInfoPluginUtils.swift in Sources */,
 				53DEA6102E03D05A00D6C371 /* AsyncChannel.swift in Sources */,
+				5328B8772E3B7E4D0051A202 /* ObjCUserIdentity.swift in Sources */,
 				53DEA6112E03D05A00D6C371 /* LifecycleManagementUtils.swift in Sources */,
 				53DEA6122E03D05A00D6C371 /* SwiftLogger.swift in Sources */,
 				53DEA6132E03D05A00D6C371 /* StartupFlushPolicy.swift in Sources */,
+				5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */,
 				53DEA6142E03D05A00D6C371 /* Analytics.swift in Sources */,
 				53DEA6152E03D05A00D6C371 /* BasicStorage.swift in Sources */,
 				53DEA6162E03D05A00D6C371 /* ObjCOption.swift in Sources */,

--- a/Sources/RudderStackAnalytics/Events/AliasEvent.swift
+++ b/Sources/RudderStackAnalytics/Events/AliasEvent.swift
@@ -14,46 +14,46 @@ import Foundation
 
  - Conforms to: `Event`
  */
-struct AliasEvent: Event {
+public struct AliasEvent: Event {
 
     /// The type of the event, defaulting to `.alias`.
-    var type: EventType = .alias
+    public var type: EventType = .alias
 
     /// A unique identifier for the event, initialized with a random UUID string.
-    var messageId: String = .randomUUIDString
+    public var messageId: String = .randomUUIDString
 
     /// The timestamp of when the event occurred, defaulting to the current time.
-    var originalTimestamp: String = .currentTimeStamp
+    public var originalTimestamp: String = .currentTimeStamp
 
     /// An optional anonymous identifier for the user associated with the event.
-    var anonymousId: String?
+    public var anonymousId: String?
 
     /// The unique identifier for the user.
-    var userId: String?
+    public var userId: String?
 
     /// The channel through which the event was sent (e.g., "mobile" or "web").
-    var channel: String?
+    public var channel: String?
 
     /// A dictionary specifying integration settings for the event.
-    var integrations: [String: AnyCodable]?
+    public var integrations: [String: AnyCodable]?
 
     /// The timestamp of when the event was sent.
-    var sentAt: String?
+    public var sentAt: String?
 
     /// Additional context information for the event, provided as a dictionary.
-    var context: [String: AnyCodable]?
+    public var context: [String: AnyCodable]?
 
     /// Custom traits or attributes associated with the event.
-    var traits: CodableCollection?
+    public var traits: CodableCollection?
 
     /// Holds the associated values for an event.
-    var options: RudderOption?
+    public var options: RudderOption?
     
     /// The user identity object containing user details, such as identifiers and traits.
-    var userIdentity: UserIdentity?
+    public var userIdentity: UserIdentity?
 
     /// The previous user identifier that the new identifier (`userId`) is linked to.
-    var previousId: String
+    public var previousId: String
 
     /**
      Initializes an `AliasEvent` with the specified previous identifier, options, and user identity.
@@ -65,7 +65,7 @@ struct AliasEvent: Event {
 
      This initializer also applies default values for integrations and context if they are not explicitly provided.
      */
-    init(previousId: String, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
+    public init(previousId: String, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
         self.previousId = previousId
         self.userIdentity = userIdentity ?? UserIdentity()
         self.options = options ?? RudderOption()

--- a/Sources/RudderStackAnalytics/Events/GroupEvent.swift
+++ b/Sources/RudderStackAnalytics/Events/GroupEvent.swift
@@ -16,46 +16,46 @@ import Foundation
 
  - Conforms to: `Event`
  */
-struct GroupEvent: Event {
+public struct GroupEvent: Event {
     
     /// The type of the event, defaulting to `.group`.
-    var type: EventType = .group
+    public var type: EventType = .group
     
     /// A unique identifier for the event.
-    var messageId: String = .randomUUIDString
+    public var messageId: String = .randomUUIDString
     
     /// The timestamp of when the event occurred, defaulting to the current time.
-    var originalTimestamp: String = .currentTimeStamp
+    public var originalTimestamp: String = .currentTimeStamp
     
     /// The anonymous identifier for the user associated with the event.
-    var anonymousId: String?
+    public var anonymousId: String?
     
     /// The channel through which the event was sent.
-    var channel: String?
+    public var channel: String?
     
     /// A dictionary of integration settings for the event.
-    var integrations: [String: AnyCodable]?
+    public var integrations: [String: AnyCodable]?
     
     /// The timestamp of when the event was sent.
-    var sentAt: String?
+    public var sentAt: String?
     
     /// Additional context information for the event, provided as a dictionary.
-    var context: [String: AnyCodable]?
+    public var context: [String: AnyCodable]?
     
     /// The unique identifier for the user.
-    var userId: String?
+    public var userId: String?
     
     /// The unique identifier of the group being associated with the user.
-    var groupId: String
+    public var groupId: String
     
     /// Custom traits or attributes associated with the group.
-    var traits: CodableCollection?
+    public var traits: CodableCollection?
 
     /// Holds the associated values for an event.
-    var options: RudderOption?
+    public var options: RudderOption?
     
     /// The identity values of the user associated with the event.
-    var userIdentity: UserIdentity?
+    public var userIdentity: UserIdentity?
     
     /**
      Initializes a `GroupEvent` with the specified group identifier, traits, and options and user identity values.
@@ -68,7 +68,7 @@ struct GroupEvent: Event {
 
      This initializer also processes and includes default values, such as default integrations and context if they are not provided.
      */
-    init(groupId: String, traits: Traits? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
+    public init(groupId: String, traits: Traits? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
         self.groupId = groupId
         self.traits = CodableCollection(dictionary: traits)
         self.userIdentity = userIdentity ?? UserIdentity()

--- a/Sources/RudderStackAnalytics/Events/IdentifyEvent.swift
+++ b/Sources/RudderStackAnalytics/Events/IdentifyEvent.swift
@@ -14,46 +14,46 @@ import Foundation
 
  - Conforms to: `Event`
  */
-struct IdentifyEvent: Event {
+public struct IdentifyEvent: Event {
     
     /// The type of the event, defaulting to `.identify`.
-    var type: EventType = .identify
+    public var type: EventType = .identify
 
     /// A unique identifier for the event, initialized with a random UUID string.
-    var messageId: String = .randomUUIDString
+    public var messageId: String = .randomUUIDString
 
     /// The timestamp of when the event occurred, defaulting to the current time.
-    var originalTimestamp: String = .currentTimeStamp
+    public var originalTimestamp: String = .currentTimeStamp
 
     /// The anonymous identifier for the user associated with the event.
-    var anonymousId: String?
+    public var anonymousId: String?
 
     /// The channel through which the event was sent (e.g., "mobile" or "web").
-    var channel: String?
+    public var channel: String?
 
     /// A dictionary of integration settings for the event.
-    var integrations: [String: AnyCodable]?
+    public var integrations: [String: AnyCodable]?
 
     /// The timestamp of when the event was sent.
-    var sentAt: String?
+    public var sentAt: String?
 
     /// Additional context information for the event, provided as a dictionary.
-    var context: [String: AnyCodable]?
+    public var context: [String: AnyCodable]?
 
     /// Custom traits or attributes associated with the user profile.
-    var traits: CodableCollection?
+    public var traits: CodableCollection?
 
     /// The name of the event being tracked.
-    var event: String
+    public var event: String
     
     /// The unique identifier for the user.
-    var userId: String?
+    public var userId: String?
 
     /// Holds the associated values for an event.
-    var options: RudderOption?
+    public var options: RudderOption?
     
     /// The identity values of the user associated with the event.
-    var userIdentity: UserIdentity?
+    public var userIdentity: UserIdentity?
 
     /**
      Initializes an `IdentifyEvent` with the specified traits, options, and user identity values.
@@ -65,7 +65,7 @@ struct IdentifyEvent: Event {
 
      This initializer also populates default values such as the anonymous ID and integrations if they are not provided.
      */
-    init(options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
+    public init(options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
         self.userIdentity = userIdentity ?? UserIdentity()
         self.event = self.type.rawValue
         self.options = options ?? RudderOption()

--- a/Sources/RudderStackAnalytics/Events/ScreenEvent.swift
+++ b/Sources/RudderStackAnalytics/Events/ScreenEvent.swift
@@ -16,52 +16,52 @@ import Foundation
 
  - Conforms to: `Event`
  */
-struct ScreenEvent: Event {
+public struct ScreenEvent: Event {
     
     /// The type of the event, defaulting to `.screen`.
-    var type: EventType = .screen
+    public var type: EventType = .screen
     
     /// A unique identifier for the event.
-    var messageId: String = .randomUUIDString
+    public var messageId: String = .randomUUIDString
     
     /// The timestamp of when the event occurred, defaulting to the current time.
-    var originalTimestamp: String = .currentTimeStamp
+    public var originalTimestamp: String = .currentTimeStamp
     
     /// The anonymous identifier for the user associated with the event.
-    var anonymousId: String?
+    public var anonymousId: String?
     
     /// The channel through which the event was sent.
-    var channel: String?
+    public var channel: String?
     
     /// A dictionary of integration settings for the event.
-    var integrations: [String: AnyCodable]?
+    public var integrations: [String: AnyCodable]?
     
     /// The timestamp of when the event was sent.
-    var sentAt: String?
+    public var sentAt: String?
     
     /// Additional context information for the event, provided as a dictionary.
-    var context: [String: AnyCodable]?
+    public var context: [String: AnyCodable]?
     
     /// Custom traits or attributes associated with the event.
-    var traits: CodableCollection?
+    public var traits: CodableCollection?
     
     /// The unique identifier for the user.
-    var userId: String?
+    public var userId: String?
     
     /// The name of the screen or page being tracked.
-    var event: String
+    public var event: String
     
     /// The category of the screen, if any.
-    var category: String?
+    public var category: String?
     
     /// Additional properties or metadata for the screen event.
-    var properties: CodableCollection?
+    public var properties: CodableCollection?
 
     /// Holds the associated values for an event.
-    var options: RudderOption?
+    public var options: RudderOption?
     
     /// The identity values of the user associated with the event.
-    var userIdentity: UserIdentity?
+    public var userIdentity: UserIdentity?
     
     /**
      Initializes a `ScreenEvent` with the specified screen name, category, properties, options and user identity values.
@@ -75,7 +75,7 @@ struct ScreenEvent: Event {
 
      This initializer also processes and includes default properties such as the screen name and category in the event's properties, if they are provided.
      */
-    init(screenName: String, category: String? = nil, properties: Properties? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
+    public init(screenName: String, category: String? = nil, properties: Properties? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
         self.event = screenName
         
         var updatedProperties = properties ?? Properties()

--- a/Sources/RudderStackAnalytics/Events/TrackEvent.swift
+++ b/Sources/RudderStackAnalytics/Events/TrackEvent.swift
@@ -16,49 +16,49 @@ import Foundation
 
  - Conforms to: `Event`
  */
-struct TrackEvent: Event {
+public struct TrackEvent: Event {
     
     /// The type of the event, defaulting to `.track`.
-    var type: EventType = .track
+    public var type: EventType = .track
     
     /// A unique identifier for the event.
-    var messageId: String = .randomUUIDString
+    public var messageId: String = .randomUUIDString
     
     /// The timestamp of when the event occurred, defaulting to the current time.
-    var originalTimestamp: String = .currentTimeStamp
+    public var originalTimestamp: String = .currentTimeStamp
     
     /// The anonymous identifier for the user associated with the event.
-    var anonymousId: String?
+    public var anonymousId: String?
     
     /// The channel through which the event was sent.
-    var channel: String?
+    public var channel: String?
     
     /// A dictionary of integration settings for the event.
-    var integrations: [String: AnyCodable]?
+    public var integrations: [String: AnyCodable]?
     
     /// The timestamp of when the event was sent.
-    var sentAt: String?
+    public var sentAt: String?
     
     /// Additional context information for the event, provided as a dictionary.
-    var context: [String: AnyCodable]?
+    public var context: [String: AnyCodable]?
     
     /// Custom traits or attributes associated with the event.
-    var traits: CodableCollection?
+    public var traits: CodableCollection?
     
     /// The name of the event being tracked.
-    var event: String
+    public var event: String
     
     /// The unique identifier for the user.
-    var userId: String?
+    public var userId: String?
     
     /// Additional properties or metadata for the event.
-    var properties: CodableCollection?
+    public var properties: CodableCollection?
 
     /// Holds the associated values for an event.
-    var options: RudderOption?
+    public var options: RudderOption?
     
     /// The identity values of the user associated with the event.
-    var userIdentity: UserIdentity?
+    public var userIdentity: UserIdentity?
     
     /**
      Initializes a `TrackEvent` with the specified event name, properties, options and user identity values.
@@ -71,7 +71,7 @@ struct TrackEvent: Event {
 
      This initializer also populates default values such as the anonymous ID and integrations if they are not provided.
      */
-    init(event: String, properties: Properties? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
+    public init(event: String, properties: Properties? = nil, options: RudderOption? = nil, userIdentity: UserIdentity? = nil) {
         self.event = event
         self.properties = CodableCollection(dictionary: properties)
         self.userIdentity = userIdentity ?? UserIdentity()

--- a/Sources/RudderStackAnalytics/ObjC/ObjCAliasEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCAliasEvent.swift
@@ -40,65 +40,47 @@ public class ObjCAliasEvent: ObjCEvent {
     }
     
     /**
-     Initializes an `ObjCAliasEvent` with the specified new ID, previous identifier, options, and user identity.
+     Initializes an `ObjCAliasEvent` with the specified previous identifier, options, and user identity.
      
      - Parameters:
-        - newId: The new user ID.
         - previousId: The existing identifier for the user that is being linked to a new identifier. Defaults to `nil`.
         - options: Custom options for the event, including integrations and context. Defaults to `nil`.
         - userIdentity: The user's identity information. Defaults to `nil`.
      */
     @objc
-    public init(newId: String, previousId: String? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+    public init(previousId: String, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
         let swiftUserIdentity = userIdentity?.userIdentity
-        
-        // Use the previousId from parameter, or fallback to a default
-        let actualPreviousId = previousId ?? ""
-        
+                
         let aliasEvent = AliasEvent(
-            previousId: actualPreviousId,
+            previousId: previousId,
             options: options,
             userIdentity: swiftUserIdentity
         )
         
         super.init(event: aliasEvent)
-        
-        // Set the new user ID after initialization
-        self.userId = newId
     }
 
     /**
-     Convenience initializer for creating an alias event with just a new ID.
-     
-     - Parameter newId: The new user ID.
-     */
-    @objc
-    public convenience init(newId: String) {
-        self.init(newId: newId, previousId: nil, options: nil, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for creating an alias event with a new ID and previous ID.
+     Convenience initializer for creating an alias event with a previous ID.
      
      - Parameters:
-        - newId: The new user ID.
         - previousId: The previous user ID.
      */
     @objc
-    public convenience init(newId: String, previousId: String) {
-        self.init(newId: newId, previousId: previousId, options: nil, userIdentity: nil)
+    public convenience init(previousId: String) {
+        self.init(previousId: previousId, options: nil, userIdentity: nil)
     }
 
     /**
-     Convenience initializer for creating an alias event with a new ID and options.
+     Convenience initializer for creating an alias event with a previous ID and options.
      
      - Parameters:
-        - newId: The new user ID.
-        - options: Additional options.
+        - previousId: The previous user ID.
+        - options: Custom options for the event.
      */
     @objc
-    public convenience init(newId: String, options: RudderOption) {
-        self.init(newId: newId, previousId: nil, options: options, userIdentity: nil)
+    public convenience init(previousId: String, options: RudderOption) {
+        self.init(previousId: previousId, options: options, userIdentity: nil)
     }
 
     // MARK: - Objective-C Compatible Properties

--- a/Sources/RudderStackAnalytics/ObjC/ObjCAliasEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCAliasEvent.swift
@@ -1,0 +1,134 @@
+//
+//  ObjCAliasEvent.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 01/08/25.
+//
+
+import Foundation
+
+// MARK: - ObjCAliasEvent
+/**
+ A class that provides an Objective-C compatible interface to the internal `AliasEvent` model.
+ 
+ Useful for exposing alias event data to Objective-C codebases, allowing manipulation
+ of user identifier linking and other alias-specific metadata.
+ */
+@objc(RSSAliasEvent)
+public class ObjCAliasEvent: ObjCEvent {
+    
+    /**
+     The underlying Swift `AliasEvent` instance.
+     */
+    private var aliasEvent: AliasEvent {
+        get {
+            guard let aliasEvent = event as? AliasEvent else {
+                fatalError("ObjCAliasEvent should only be initialized with AliasEvent instances")
+            }
+            return aliasEvent
+        }
+        set { event = newValue }
+    }
+    
+    /**
+     Initializes an `ObjCAliasEvent` with the given `AliasEvent`.
+     
+     - Parameter event: The underlying Swift alias event model to wrap.
+     */
+    init(event: AliasEvent) {
+        super.init(event: event)
+    }
+    
+    /**
+     Initializes an `ObjCAliasEvent` with the specified new ID, previous identifier, options, and user identity.
+     
+     - Parameters:
+        - newId: The new user ID.
+        - previousId: The existing identifier for the user that is being linked to a new identifier. Defaults to `nil`.
+        - options: Custom options for the event, including integrations and context. Defaults to `nil`.
+        - userIdentity: The user's identity information. Defaults to `nil`.
+     */
+    @objc
+    public init(newId: String, previousId: String? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+        let swiftUserIdentity = userIdentity?.userIdentity
+        
+        // Use the previousId from parameter, or fallback to a default
+        let actualPreviousId = previousId ?? ""
+        
+        let aliasEvent = AliasEvent(
+            previousId: actualPreviousId,
+            options: options,
+            userIdentity: swiftUserIdentity
+        )
+        
+        super.init(event: aliasEvent)
+        
+        // Set the new user ID after initialization
+        self.userId = newId
+    }
+
+    /**
+     Convenience initializer for creating an alias event with just a new ID.
+     
+     - Parameter newId: The new user ID.
+     */
+    @objc
+    public convenience init(newId: String) {
+        self.init(newId: newId, previousId: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating an alias event with a new ID and previous ID.
+     
+     - Parameters:
+        - newId: The new user ID.
+        - previousId: The previous user ID.
+     */
+    @objc
+    public convenience init(newId: String, previousId: String) {
+        self.init(newId: newId, previousId: previousId, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating an alias event with a new ID and options.
+     
+     - Parameters:
+        - newId: The new user ID.
+        - options: Additional options.
+     */
+    @objc
+    public convenience init(newId: String, options: RudderOption) {
+        self.init(newId: newId, previousId: nil, options: options, userIdentity: nil)
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     The previous user identifier that the new identifier is linked to.
+     */
+    @objc public var previousId: String {
+        get { aliasEvent.previousId }
+        set { aliasEvent.previousId = newValue }
+    }
+
+    /**
+     Custom options for the event, including integrations and context.
+     */
+    @objc public var options: RudderOption? {
+        get { aliasEvent.options }
+        set { aliasEvent.options = newValue }
+    }
+
+    /**
+     The user's identity information associated with the event.
+     */
+    @objc public var userIdentity: ObjCUserIdentity? {
+        get {
+            guard let swiftUserIdentity = aliasEvent.userIdentity else { return nil }
+            return ObjCUserIdentity(userIdentity: swiftUserIdentity)
+        }
+        set {
+            aliasEvent.userIdentity = newValue?.userIdentity
+        }
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCGroupEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCGroupEvent.swift
@@ -1,0 +1,130 @@
+//
+//  ObjCGroupEvent.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 01/08/25.
+//
+
+import Foundation
+
+// MARK: - ObjCGroupEvent
+/**
+ A class that provides an Objective-C compatible interface to the internal `GroupEvent` model.
+ 
+ Useful for exposing group event data to Objective-C codebases, allowing manipulation
+ of group ID, traits, and other group-specific metadata.
+ */
+@objc(RSSGroupEvent)
+public class ObjCGroupEvent: ObjCEvent {
+    
+    /**
+     The underlying Swift `GroupEvent` instance.
+     */
+    private var groupEvent: GroupEvent {
+        get {
+            guard let groupEvent = event as? GroupEvent else {
+                fatalError("ObjCGroupEvent should only be initialized with GroupEvent instances")
+            }
+            return groupEvent
+        }
+        set { event = newValue }
+    }
+    
+    /**
+     Initializes an `ObjCGroupEvent` with the given `GroupEvent`.
+     
+     - Parameter event: The underlying Swift group event model to wrap.
+     */
+    init(event: GroupEvent) {
+        super.init(event: event)
+    }
+    
+    /**
+     Initializes an `ObjCGroupEvent` with the specified group ID, traits, and options.
+     
+     - Parameters:
+        - groupId: The unique identifier of the group being associated with the user.
+        - traits: Custom traits or attributes associated with the group. Defaults to `nil`.
+        - options: Custom options for the event, including integrations and context. Defaults to `nil`.
+        - userIdentity: The user's identity information. Defaults to `nil`.
+     */
+    @objc
+    public init(groupId: String, traits: [String: Any]? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+        let swiftTraits = traits?.objCSanitized
+        let swiftUserIdentity = userIdentity?.userIdentity
+        
+        let groupEvent = GroupEvent(
+            groupId: groupId,
+            traits: swiftTraits,
+            options: options,
+            userIdentity: swiftUserIdentity
+        )
+        
+        super.init(event: groupEvent)
+    }
+
+    /**
+     Convenience initializer for creating a group event with just a group ID.
+     
+     - Parameter groupId: The unique identifier of the group being associated with the user.
+     */
+    @objc
+    public convenience init(groupId: String) {
+        self.init(groupId: groupId, traits: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a group event with a group ID and traits.
+     
+     - Parameters:
+        - groupId: The unique identifier of the group being associated with the user.
+        - traits: Custom traits or attributes associated with the group.
+     */
+    @objc
+    public convenience init(groupId: String, traits: [String: Any]) {
+        self.init(groupId: groupId, traits: traits, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a group event with a group ID and options.
+     
+     - Parameters:
+        - groupId: The unique identifier of the group being associated with the user.
+        - options: Additional options for the event.
+     */
+    @objc
+    public convenience init(groupId: String, options: RudderOption) {
+        self.init(groupId: groupId, traits: nil, options: options, userIdentity: nil)
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     The unique identifier of the group being associated with the user.
+     */
+    @objc public var groupId: String {
+        get { groupEvent.groupId }
+        set { groupEvent.groupId = newValue }
+    }
+
+    /**
+     Custom options for the event, including integrations and context.
+     */
+    @objc public var options: RudderOption? {
+        get { groupEvent.options }
+        set { groupEvent.options = newValue }
+    }
+
+    /**
+     The user's identity information associated with the event.
+     */
+    @objc public var userIdentity: ObjCUserIdentity? {
+        get {
+            guard let swiftUserIdentity = groupEvent.userIdentity else { return nil }
+            return ObjCUserIdentity(userIdentity: swiftUserIdentity)
+        }
+        set {
+            groupEvent.userIdentity = newValue?.userIdentity
+        }
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCIdentifyEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCIdentifyEvent.swift
@@ -40,16 +40,14 @@ public class ObjCIdentifyEvent: ObjCEvent {
     }
     
     /**
-     Initializes an `ObjCIdentifyEvent` with the specified user ID, traits, options and user identity.
+     Initializes an `ObjCIdentifyEvent` with the specified options and user identity.
      
      - Parameters:
-        - userId: The user ID. Defaults to `nil`.
-        - traits: Custom traits or attributes for the user. Defaults to `nil`.
         - options: Custom options for the event, including integrations and context. Defaults to `nil`.
         - userIdentity: The user's identity information. Defaults to `nil`.
      */
     @objc
-    public init(userId: String? = nil, traits: [String: Any]? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+    public init(options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
         let swiftUserIdentity = userIdentity?.userIdentity
         
         let identifyEvent = IdentifyEvent(
@@ -58,14 +56,6 @@ public class ObjCIdentifyEvent: ObjCEvent {
         )
         
         super.init(event: identifyEvent)
-        
-        // Set userId and traits after initialization
-        if let userId = userId {
-            self.userId = userId
-        }
-        if let traits = traits {
-            self.traits = traits
-        }
     }
 
     /**
@@ -73,63 +63,7 @@ public class ObjCIdentifyEvent: ObjCEvent {
      */
     @objc
     public convenience init() {
-        self.init(userId: nil, traits: nil, options: nil, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for identifying a user by user ID.
-     
-     - Parameter userId: The user ID.
-     */
-    @objc
-    public convenience init(userId: String) {
-        self.init(userId: userId, traits: nil, options: nil, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for identifying a user by traits only.
-     
-     - Parameter traits: Traits associated with the user.
-     */
-    @objc
-    public convenience init(traits: [String: Any]) {
-        self.init(userId: nil, traits: traits, options: nil, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for identifying a user by user ID and traits.
-     
-     - Parameters:
-        - userId: The user ID.
-        - traits: Traits associated with the user.
-     */
-    @objc
-    public convenience init(userId: String, traits: [String: Any]) {
-        self.init(userId: userId, traits: traits, options: nil, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for identifying a user by user ID and options.
-     
-     - Parameters:
-        - userId: The user ID.
-        - options: Additional options.
-     */
-    @objc
-    public convenience init(userId: String, options: RudderOption) {
-        self.init(userId: userId, traits: nil, options: options, userIdentity: nil)
-    }
-
-    /**
-     Convenience initializer for identifying a user by traits and options.
-     
-     - Parameters:
-        - traits: Traits associated with the user.
-        - options: Additional options.
-     */
-    @objc
-    public convenience init(traits: [String: Any], options: RudderOption) {
-        self.init(userId: nil, traits: traits, options: options, userIdentity: nil)
+        self.init(options: nil, userIdentity: nil)
     }
 
     // MARK: - Objective-C Compatible Properties

--- a/Sources/RudderStackAnalytics/ObjC/ObjCIdentifyEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCIdentifyEvent.swift
@@ -1,0 +1,157 @@
+//
+//  ObjCIdentifyEvent.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 01/08/25.
+//
+
+import Foundation
+
+// MARK: - ObjCIdentifyEvent
+/**
+ A class that provides an Objective-C compatible interface to the internal `IdentifyEvent` model.
+ 
+ Useful for exposing identify event data to Objective-C codebases, allowing manipulation
+ of user traits and other identify-specific metadata.
+ */
+@objc(RSSIdentifyEvent)
+public class ObjCIdentifyEvent: ObjCEvent {
+    
+    /**
+     The underlying Swift `IdentifyEvent` instance.
+     */
+    private var identifyEvent: IdentifyEvent {
+        get {
+            guard let identifyEvent = event as? IdentifyEvent else {
+                fatalError("ObjCIdentifyEvent should only be initialized with IdentifyEvent instances")
+            }
+            return identifyEvent
+        }
+        set { event = newValue }
+    }
+    
+    /**
+     Initializes an `ObjCIdentifyEvent` with the given `IdentifyEvent`.
+     
+     - Parameter event: The underlying Swift identify event model to wrap.
+     */
+    init(event: IdentifyEvent) {
+        super.init(event: event)
+    }
+    
+    /**
+     Initializes an `ObjCIdentifyEvent` with the specified user ID, traits, options and user identity.
+     
+     - Parameters:
+        - userId: The user ID. Defaults to `nil`.
+        - traits: Custom traits or attributes for the user. Defaults to `nil`.
+        - options: Custom options for the event, including integrations and context. Defaults to `nil`.
+        - userIdentity: The user's identity information. Defaults to `nil`.
+     */
+    @objc
+    public init(userId: String? = nil, traits: [String: Any]? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+        let swiftUserIdentity = userIdentity?.userIdentity
+        
+        let identifyEvent = IdentifyEvent(
+            options: options,
+            userIdentity: swiftUserIdentity
+        )
+        
+        super.init(event: identifyEvent)
+        
+        // Set userId and traits after initialization
+        if let userId = userId {
+            self.userId = userId
+        }
+        if let traits = traits {
+            self.traits = traits
+        }
+    }
+
+    /**
+     Convenience initializer for creating an identify event with default values.
+     */
+    @objc
+    public convenience init() {
+        self.init(userId: nil, traits: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for identifying a user by user ID.
+     
+     - Parameter userId: The user ID.
+     */
+    @objc
+    public convenience init(userId: String) {
+        self.init(userId: userId, traits: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for identifying a user by traits only.
+     
+     - Parameter traits: Traits associated with the user.
+     */
+    @objc
+    public convenience init(traits: [String: Any]) {
+        self.init(userId: nil, traits: traits, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for identifying a user by user ID and traits.
+     
+     - Parameters:
+        - userId: The user ID.
+        - traits: Traits associated with the user.
+     */
+    @objc
+    public convenience init(userId: String, traits: [String: Any]) {
+        self.init(userId: userId, traits: traits, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for identifying a user by user ID and options.
+     
+     - Parameters:
+        - userId: The user ID.
+        - options: Additional options.
+     */
+    @objc
+    public convenience init(userId: String, options: RudderOption) {
+        self.init(userId: userId, traits: nil, options: options, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for identifying a user by traits and options.
+     
+     - Parameters:
+        - traits: Traits associated with the user.
+        - options: Additional options.
+     */
+    @objc
+    public convenience init(traits: [String: Any], options: RudderOption) {
+        self.init(userId: nil, traits: traits, options: options, userIdentity: nil)
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     Custom options for the event, including integrations and context.
+     */
+    @objc public var options: RudderOption? {
+        get { identifyEvent.options }
+        set { identifyEvent.options = newValue }
+    }
+
+    /**
+     The user's identity information associated with the event.
+     */
+    @objc public var userIdentity: ObjCUserIdentity? {
+        get {
+            guard let swiftUserIdentity = identifyEvent.userIdentity else { return nil }
+            return ObjCUserIdentity(userIdentity: swiftUserIdentity)
+        }
+        set {
+            identifyEvent.userIdentity = newValue?.userIdentity
+        }
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCPlugin.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCPlugin.swift
@@ -87,8 +87,23 @@ final class ObjCPluginAdapter: Plugin {
      - Returns: The processed event or `nil` to drop the event.
      */
     func intercept(event: Event) -> Event? {
-        let objcEvent = ObjCEvent(event: event)
+        let objcEvent = createObjCEvent(from: event)
         return objcPlugin.intercept(objcEvent)?.event
+    }
+    
+    /**
+     Creates the appropriate ObjC event wrapper based on the event type.
+     
+     - Parameter event: The Swift event to wrap.
+     - Returns: The appropriate ObjC event wrapper.
+     */
+    private func createObjCEvent(from event: Event) -> ObjCEvent {
+        switch event {
+        case let trackEvent as TrackEvent:
+            return ObjCTrackEvent(event: trackEvent)
+        default:
+            return ObjCEvent(event: event)
+        }
     }
 
     /**

--- a/Sources/RudderStackAnalytics/ObjC/ObjCPlugin.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCPlugin.swift
@@ -101,6 +101,14 @@ final class ObjCPluginAdapter: Plugin {
         switch event {
         case let trackEvent as TrackEvent:
             return ObjCTrackEvent(event: trackEvent)
+        case let screenEvent as ScreenEvent:
+            return ObjCScreenEvent(event: screenEvent)
+        case let groupEvent as GroupEvent:
+            return ObjCGroupEvent(event: groupEvent)
+        case let identifyEvent as IdentifyEvent:
+            return ObjCIdentifyEvent(event: identifyEvent)
+        case let aliasEvent as AliasEvent:
+            return ObjCAliasEvent(event: aliasEvent)
         default:
             return ObjCEvent(event: event)
         }

--- a/Sources/RudderStackAnalytics/ObjC/ObjCScreenEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCScreenEvent.swift
@@ -1,0 +1,207 @@
+//
+//  ObjCScreenEvent.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 01/08/25.
+//
+
+import Foundation
+
+// MARK: - ObjCScreenEvent
+/**
+ A class that provides an Objective-C compatible interface to the internal `ScreenEvent` model.
+ 
+ Useful for exposing screen event data to Objective-C codebases, allowing manipulation
+ of screen name, category, properties, and other screen-specific metadata.
+ */
+@objc(RSSScreenEvent)
+public class ObjCScreenEvent: ObjCEvent {
+    
+    /**
+     The underlying Swift `ScreenEvent` instance.
+     */
+    private var screenEvent: ScreenEvent {
+        get {
+            guard let screenEvent = event as? ScreenEvent else {
+                fatalError("ObjCScreenEvent should only be initialized with ScreenEvent instances")
+            }
+            return screenEvent
+        }
+        set { event = newValue }
+    }
+    
+    /**
+     Initializes an `ObjCScreenEvent` with the given `ScreenEvent`.
+     
+     - Parameter event: The underlying Swift screen event model to wrap.
+     */
+    init(event: ScreenEvent) {
+        super.init(event: event)
+    }
+    
+    /**
+     Initializes an `ObjCScreenEvent` with the specified screen name, category, properties, and options.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - category: The category of the screen, if applicable. Defaults to `nil`.
+        - properties: Additional properties or metadata associated with the screen event. Defaults to `nil`.
+        - options: Custom options for the event, including integrations and context. Defaults to `nil`.
+        - userIdentity: The user's identity information. Defaults to `nil`.
+     */
+    @objc
+    public init(screenName: String, category: String? = nil, properties: [String: Any]? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+        let swiftProperties = properties?.objCSanitized
+        let swiftUserIdentity = userIdentity?.userIdentity
+        
+        let screenEvent = ScreenEvent(
+            screenName: screenName,
+            category: category,
+            properties: swiftProperties,
+            options: options,
+            userIdentity: swiftUserIdentity
+        )
+        
+        super.init(event: screenEvent)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with just a screen name.
+     
+     - Parameter screenName: The name of the screen or page being tracked.
+     */
+    @objc
+    public convenience init(screenName: String) {
+        self.init(screenName: screenName, category: nil, properties: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name and category.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - category: The category of the screen.
+     */
+    @objc
+    public convenience init(screenName: String, category: String) {
+        self.init(screenName: screenName, category: category, properties: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name and properties.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - properties: Additional properties or metadata associated with the screen event.
+     */
+    @objc
+    public convenience init(screenName: String, properties: [String: Any]) {
+        self.init(screenName: screenName, category: nil, properties: properties, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name and options.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - options: Additional options for screen tracking.
+     */
+    @objc
+    public convenience init(screenName: String, options: RudderOption) {
+        self.init(screenName: screenName, category: nil, properties: nil, options: options, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name, category, and properties.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - category: The category of the screen.
+        - properties: Additional properties or metadata associated with the screen event.
+     */
+    @objc
+    public convenience init(screenName: String, category: String, properties: [String: Any]) {
+        self.init(screenName: screenName, category: category, properties: properties, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name, category, and options.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - category: The category of the screen.
+        - options: Additional options for screen tracking.
+     */
+    @objc
+    public convenience init(screenName: String, category: String, options: RudderOption) {
+        self.init(screenName: screenName, category: category, properties: nil, options: options, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a screen event with a screen name, properties, and options.
+     
+     - Parameters:
+        - screenName: The name of the screen or page being tracked.
+        - properties: Additional properties or metadata associated with the screen event.
+        - options: Additional options for screen tracking.
+     */
+    @objc
+    public convenience init(screenName: String, properties: [String: Any], options: RudderOption) {
+        self.init(screenName: screenName, category: nil, properties: properties, options: options, userIdentity: nil)
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     The name of the screen or page being tracked.
+     */
+    @objc public var screenName: String {
+        get { screenEvent.event }
+        set { screenEvent.event = newValue }
+    }
+
+    /**
+     The category of the screen, if any.
+     */
+    @objc public var category: String? {
+        get { screenEvent.category }
+        set { screenEvent.category = newValue }
+    }
+
+    /**
+     Additional properties or metadata for the screen event.
+     */
+    @objc public var properties: [String: Any]? {
+        get {
+            screenEvent.properties?.dictionary?.rawDictionary
+        }
+        set {
+            guard let dict = newValue?.objCSanitized else {
+                screenEvent.properties = nil
+                return
+            }
+            screenEvent.properties = CodableCollection(dictionary: dict)
+        }
+    }
+
+    /**
+     Custom options for the event, including integrations and context.
+     */
+    @objc public var options: RudderOption? {
+        get { screenEvent.options }
+        set { screenEvent.options = newValue }
+    }
+
+    /**
+     The user's identity information associated with the event.
+     */
+    @objc public var userIdentity: ObjCUserIdentity? {
+        get {
+            guard let swiftUserIdentity = screenEvent.userIdentity else { return nil }
+            return ObjCUserIdentity(userIdentity: swiftUserIdentity)
+        }
+        set {
+            screenEvent.userIdentity = newValue?.userIdentity
+        }
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCTrackEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCTrackEvent.swift
@@ -1,0 +1,134 @@
+//
+//  ObjCTrackEvent.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+import Foundation
+
+// MARK: - ObjCTrackEvent
+/**
+ A class that provides an Objective-C compatible interface to the internal `TrackEvent` model.
+ 
+ Useful for exposing track event data to Objective-C codebases, allowing manipulation
+ of event name, properties, and other track-specific metadata.
+ */
+@objc(RSSTrackEvent)
+public class ObjCTrackEvent: ObjCEvent {
+    
+    /**
+     The underlying Swift `TrackEvent` instance.
+     */
+    private var trackEvent: TrackEvent {
+        get { 
+            guard let trackEvent = event as? TrackEvent else {
+                fatalError("ObjCTrackEvent should only be initialized with TrackEvent instances")
+            }
+            return trackEvent
+        }
+        set { event = newValue }
+    }
+    
+    /**
+     Initializes an `ObjCTrackEvent` with the given `TrackEvent`.
+     
+     - Parameter event: The underlying Swift track event model to wrap.
+     */
+    init(event: TrackEvent) {
+        super.init(event: event)
+    }
+    
+    /**
+     Initializes an `ObjCTrackEvent` with the specified event name, properties, and options.
+     
+     - Parameters:
+        - eventName: The name of the event being tracked.
+        - properties: Additional properties or metadata associated with the event. Defaults to `nil`.
+        - options: Custom options for the event, including integrations and context. Defaults to `nil`.
+        - userIdentity: The user's identity information. Defaults to `nil`.
+     */
+    @objc
+    public init(eventName: String, properties: [String: Any]? = nil, options: RudderOption? = nil, userIdentity: ObjCUserIdentity? = nil) {
+        let swiftProperties = properties?.objCSanitized
+        let swiftUserIdentity = userIdentity?.userIdentity
+        
+        let trackEvent = TrackEvent(
+            event: eventName,
+            properties: swiftProperties,
+            options: options,
+            userIdentity: swiftUserIdentity
+        )
+        
+        super.init(event: trackEvent)
+    }
+
+    /**
+     Convenience initializer for creating a track event with just an event name.
+     
+     - Parameter eventName: The name of the event being tracked.
+     */
+    @objc
+    public convenience init(eventName: String) {
+        self.init(eventName: eventName, properties: nil, options: nil, userIdentity: nil)
+    }
+
+    /**
+     Convenience initializer for creating a track event with an event name and properties.
+     
+     - Parameters:
+        - eventName: The name of the event being tracked.
+        - properties: Additional properties or metadata associated with the event.
+     */
+    @objc
+    public convenience init(eventName: String, properties: [String: Any]) {
+        self.init(eventName: eventName, properties: properties, options: nil, userIdentity: nil)
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     The name of the event being tracked.
+     */
+    @objc public var eventName: String {
+        get { trackEvent.event }
+        set { trackEvent.event = newValue }
+    }
+
+    /**
+     Additional properties or metadata for the event.
+     */
+    @objc public var properties: [String: Any]? {
+        get {
+            trackEvent.properties?.dictionary?.rawDictionary
+        }
+        set {
+            guard let dict = newValue?.objCSanitized else { 
+                trackEvent.properties = nil
+                return 
+            }
+            trackEvent.properties = CodableCollection(dictionary: dict)
+        }
+    }
+
+    /**
+     Custom options for the event, including integrations and context.
+     */
+    @objc public var options: RudderOption? {
+        get { trackEvent.options }
+        set { trackEvent.options = newValue }
+    }
+
+    /**
+     The user's identity information associated with the event.
+     */
+    @objc public var userIdentity: ObjCUserIdentity? {
+        get { 
+            guard let swiftUserIdentity = trackEvent.userIdentity else { return nil }
+            return ObjCUserIdentity(userIdentity: swiftUserIdentity)
+        }
+        set { 
+            trackEvent.userIdentity = newValue?.userIdentity 
+        }
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCTrackEvent.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCTrackEvent.swift
@@ -85,6 +85,18 @@ public class ObjCTrackEvent: ObjCEvent {
         self.init(eventName: eventName, properties: properties, options: nil, userIdentity: nil)
     }
 
+    /**
+     Convenience initializer for creating a track event with an event name and options.
+     
+     - Parameters:
+        - eventName: The name of the event being tracked.
+        - options: Additional tracking options.
+     */
+    @objc
+    public convenience init(eventName: String, options: RudderOption) {
+        self.init(eventName: eventName, properties: nil, options: options, userIdentity: nil)
+    }
+
     // MARK: - Objective-C Compatible Properties
 
     /**

--- a/Sources/RudderStackAnalytics/ObjC/ObjCUserIdentity.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCUserIdentity.swift
@@ -1,0 +1,81 @@
+//
+//  ObjCUserIdentity.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 31/07/25.
+//
+
+import Foundation
+
+// MARK: - ObjCUserIdentity
+/**
+ A class that provides an Objective-C compatible interface to the internal `UserIdentity` model.
+ 
+ Useful for exposing user identity data to Objective-C codebases, allowing manipulation
+ of anonymous ID, user ID, and traits properties.
+ */
+@objc(RSSUserIdentity)
+public class ObjCUserIdentity: NSObject {
+    /**
+     The underlying Swift `UserIdentity` instance.
+     */
+    internal var userIdentity: UserIdentity
+
+    /**
+     Initializes an `ObjCUserIdentity` with the given `UserIdentity`.
+     
+     - Parameter userIdentity: The underlying Swift user identity model to wrap.
+     */
+    init(userIdentity: UserIdentity) {
+        self.userIdentity = userIdentity
+    }
+
+    /**
+     Initializes an `ObjCUserIdentity` with default values.
+     */
+    @objc
+    public override init() {
+        self.userIdentity = UserIdentity()
+        super.init()
+    }
+
+    /**
+     Initializes an `ObjCUserIdentity` with the specified identifiers and traits.
+     
+     - Parameters:
+       - anonymousId: A unique identifier for the user when they are not logged in.
+       - userId: The identifier for the user when they are logged in.
+       - traits: A dictionary of user-specific traits for storing additional metadata about the user.
+     */
+    @objc
+    public init(anonymousId: String, userId: String, traits: [String: Any]?) {
+        self.userIdentity = UserIdentity(anonymousId: anonymousId, userId: userId, traits: traits?.objCSanitized ?? Traits())
+        super.init()
+    }
+
+    // MARK: - Objective-C Compatible Properties
+
+    /**
+     A unique identifier for the user when they are not logged in.
+     */
+    @objc public var anonymousId: String {
+        get { userIdentity.anonymousId }
+        set { userIdentity.anonymousId = newValue }
+    }
+
+    /**
+     The identifier for the user when they are logged in.
+     */
+    @objc public var userId: String {
+        get { userIdentity.userId }
+        set { userIdentity.userId = newValue }
+    }
+
+    /**
+     A dictionary of user-specific traits, used to store additional metadata about the user.
+     */
+    @objc public var traits: [String: Any] {
+        get { userIdentity.traits }
+        set { userIdentity.traits = newValue.objCSanitized }
+    }
+}

--- a/Sources/RudderStackAnalytics/Plugins/Base/PluginInteractor.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Base/PluginInteractor.swift
@@ -25,9 +25,11 @@ class PluginInteractor {
     }
     
     func execute(_ event: Event) -> Event? {
-        var result = event
+        var result: Event? = event
         self.pluginList.forEach {
-            if let processed = $0.intercept(event: result) { result = processed }
+            if let processing = result {
+                result = $0.intercept(event: processing)
+            }
         }
         return result
     }

--- a/Sources/RudderStackAnalytics/StateManagement/UserIdentity.swift
+++ b/Sources/RudderStackAnalytics/StateManagement/UserIdentity.swift
@@ -23,13 +23,13 @@ import Foundation
  */
 public struct UserIdentity {
     /// A unique identifier for the user when they are not logged in. Defaults to an empty string.
-    public internal(set) var anonymousId = String.empty
+    public var anonymousId = String.empty
     
     /// The identifier for the user when they are logged in. Defaults to an empty string.
-    public internal(set) var userId = String.empty
+    public var userId = String.empty
     
     /// A dictionary of user-specific traits, used to store additional metadata about the user.
-    public internal(set) var traits = Traits()
+    public var traits = Traits()
     
     /**
      Creates and initializes a `UserIdentity` instance by reading data from the provided key-value storage.

--- a/Sources/RudderStackAnalytics/StateManagement/UserIdentity.swift
+++ b/Sources/RudderStackAnalytics/StateManagement/UserIdentity.swift
@@ -56,6 +56,21 @@ public struct UserIdentity {
         return identity
     }
     
+    /**
+     Creates a new `UserIdentity` instance with the specified identifiers and traits.
+     
+     - Parameters:
+       - anonymousId: A unique identifier for the user when they are not logged in. Defaults to an empty string.
+       - userId: The identifier for the user when they are logged in. Defaults to an empty string.
+       - traits: A dictionary of user-specific traits for storing additional metadata about the user. Defaults to an empty `Traits` object.
+     
+     This initializer allows you to create a `UserIdentity` instance with custom values for user identification and associated traits.
+     */
+    public init(anonymousId: String = "", userId: String = "", traits: Traits = Traits()) {
+        self.anonymousId = anonymousId
+        self.userId = userId
+        self.traits = traits
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Description

This PR makes all Event subclasses (`TrackEvent`, `ScreenEvent`, `GroupEvent`, `IdentifyEvent`, `AliasEvent`) and their properties public, enabling developers to create and manipulate event instances directly. Additionally, it introduces comprehensive Objective-C compatibility classes that provide a complete bridge between Swift and Objective-C codebases.

### Key Changes:
- **Public Event Models**: All event structs and their properties are now public, allowing direct instantiation and manipulation
- **Objective-C Compatibility**: New ObjC wrapper classes for all event types with type-safe interfaces
- **Enhanced Plugin System**: Improved plugin interception logic with proper event type handling
- **User Identity Support**: Added public initializer and ObjC wrapper for UserIdentity
- **Documentation**: Comprehensive documentation for all new ObjC classes and public APIs

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

### 1. Public Event Models
- Made all event structs (`TrackEvent`, `ScreenEvent`, `GroupEvent`, `IdentifyEvent`, `AliasEvent`) public
- Exposed all event properties as public, enabling direct access and manipulation
- Added public initializer to `UserIdentity` struct for custom identity creation

### 2. Objective-C Compatibility Classes
- **`ObjCTrackEvent`**: Objective-C wrapper for track events with event name and properties support
- **`ObjCScreenEvent`**: Screen event wrapper with screen name, category, and properties
- **`ObjCGroupEvent`**: Group event wrapper for user-group associations with traits support
- **`ObjCIdentifyEvent`**: Identity event wrapper for user identification with traits
- **`ObjCAliasEvent`**: Alias event wrapper for linking user identifiers
- **`ObjCUserIdentity`**: User identity wrapper with anonymous ID, user ID, and traits

### 3. Enhanced Plugin System
- Updated `ObjCPluginAdapter` to create appropriate event-specific wrappers based on event type
- Improved `PluginInteractor` execution logic to handle nil events properly during plugin chain processing
- Added comprehensive event type switching in plugin interception

### 4. Example Integration
- Added `EventFilteringPlugin` examples for both Swift and Objective-C demonstrating usage
- Updated project files to include new source files and examples

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

### Testing Public Event Models
```swift
// Swift - Direct event creation
let trackEvent = TrackEvent(event: "button_clicked", properties: ["screen": "home"])
let screenEvent = ScreenEvent(screenName: "Home", category: "Main")
let groupEvent = GroupEvent(groupId: "team_123", traits: ["name": "Engineering"])
```

### Testing Objective-C Compatibility
```objective-c
// Objective-C - Event creation and manipulation
RSSTrackEvent *trackEvent = [[RSSTrackEvent alloc] initWithEventName:@"button_clicked"];
trackEvent.properties = @{@"screen": @"home"};

RSSScreenEvent *screenEvent = [[RSSScreenEvent alloc] initWithScreenName:@"Home" category:@"Main"];

RSSGroupEvent *groupEvent = [[RSSGroupEvent alloc] initWithGroupId:@"team_123"];
groupEvent.traits = @{@"name": @"Engineering"};
```

### Testing Plugin Integration
```objective-c
// Objective-C Plugin with event type checking
- (RSSEvent *)intercept:(RSSEvent *)event {
    if ([event isKindOfClass:[RSSTrackEvent class]]) {
        RSSTrackEvent *trackEvent = (RSSTrackEvent *)event;
        // Process track event
    }
    return event;
}
```

Run the provided example projects (`SwiftUIExample` and `ObjCExample`) to see the new functionality in action, particularly the `EventFilteringPlugin` implementations.

## Breaking Changes
None. This is a purely additive change that maintains backward compatibility while expanding the public API surface.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is an API enhancement without UI changes.

## Additional Context

This implementation provides a complete bridge between Swift and Objective-C, making the SDK more accessible to diverse development teams. The public event models enable advanced use cases such as:

- Custom event creation and manipulation before sending
- Event transformation in plugins
- Advanced analytics implementations with custom event logic

The Objective-C compatibility classes maintain the same API patterns as the Swift counterparts while providing idiomatic Objective-C interfaces with proper memory management and type safety.
