### PR TITLE
feat: implement storage api to remove batch files by write key

### DIFF
--- a/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
@@ -115,6 +115,6 @@ extension EventUploader {
 // MARK: - Helpers
 extension EventUploader {
     private func deleteBatchFile(_ reference: String) async {
-        await self.storage.remove(eventReference: reference)
+        await self.storage.remove(batchReference: reference)
     }
 }

--- a/Sources/RudderStackAnalytics/Helpers/Extensions.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Extensions.swift
@@ -84,8 +84,11 @@ extension FileManager {
             storageURL = directory[0].appendingPathComponent("rudder/analytics/events", isDirectory: true)
         }
         
-        try? FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true, attributes: nil)
         return storageURL
+    }
+    
+    static func createDirectoryIfNeeded(at url: URL) {
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
     }
     
     static func createFile(at filePath: String) -> String? {
@@ -121,11 +124,11 @@ extension FileManager {
     }
     
     @discardableResult
-    static func delete(file filePath: String) -> Bool {
-        let fileUrl = URL(fileURLWithPath: filePath)
+    static func delete(item path: String) -> Bool {
+        let fileUrl = URL(fileURLWithPath: path)
         do {
             try FileManager.default.removeItem(at: fileUrl)
-            LoggerAnalytics.debug(log: "File deleted: \(filePath)")
+            LoggerAnalytics.debug(log: "Item deleted: \(path)")
             return true
         } catch {
             return false

--- a/Sources/RudderStackAnalytics/Helpers/Extensions.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Extensions.swift
@@ -128,9 +128,10 @@ extension FileManager {
         let fileUrl = URL(fileURLWithPath: path)
         do {
             try FileManager.default.removeItem(at: fileUrl)
-            LoggerAnalytics.debug(log: "Item deleted: \(path)")
+            LoggerAnalytics.debug(log: "Removed item at path: \(path)")
             return true
         } catch {
+            LoggerAnalytics.error(log: "Failed to remove item at path: \(path)", error: error)
             return false
         }
     }

--- a/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
+++ b/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
@@ -50,8 +50,8 @@ extension BasicStorage {
         return await self.dataStore.remove(reference: batchReference)
     }
     
-    func removeAll(batchReference: String) async {
-        await self.dataStore.removeAll(reference: batchReference)
+    func removeAll() async {
+        await self.dataStore.removeAll()
     }
     
     func rollover() async {

--- a/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
+++ b/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
@@ -50,6 +50,10 @@ extension BasicStorage {
         return await self.dataStore.remove(reference: batchReference)
     }
     
+    func removeAll(batchReference: String) async {
+        await self.dataStore.removeAll(reference: batchReference)
+    }
+    
     func rollover() async {
         await self.dataStore.rollover()
     }

--- a/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
+++ b/Sources/RudderStackAnalytics/Storage/BasicStorage.swift
@@ -46,8 +46,8 @@ extension BasicStorage {
         return await EventDataResult(dataItems: self.dataStore.retrieve())
     }
     
-    func remove(eventReference: String) async -> Bool {
-        return await self.dataStore.remove(reference: eventReference)
+    func remove(batchReference: String) async -> Bool {
+        return await self.dataStore.remove(reference: batchReference)
     }
     
     func rollover() async {

--- a/Sources/RudderStackAnalytics/Storage/Storage.swift
+++ b/Sources/RudderStackAnalytics/Storage/Storage.swift
@@ -82,11 +82,9 @@ protocol EventStorage {
     func remove(batchReference: String) async -> Bool
 
     /**
-     Removes all batches associated with the given reference from the storage.
-
-     - Parameter batchReference: The reference of the batches to be removed.
+     Removes all batches associated with the current write key.
      */
-    func removeAll(batchReference: String) async
+    func removeAll() async
     
     /**
      Performs a rollover operation on the storage.

--- a/Sources/RudderStackAnalytics/Storage/Storage.swift
+++ b/Sources/RudderStackAnalytics/Storage/Storage.swift
@@ -73,14 +73,14 @@ protocol EventStorage {
     func read() async -> EventDataResult
 
     /**
-     Removes a specific event from the storage.
+     Removes a specific batch from the storage.
 
-     - Parameter eventReference: The reference of the event to be removed.
-     - Returns: A `Bool` indicating whether the event was successfully removed.
+     - Parameter batchReference: The reference of the batch to be removed.
+     - Returns: A `Bool` indicating whether the batch was successfully removed.
      */
     @discardableResult
-    func remove(eventReference: String) async -> Bool
-
+    func remove(batchReference: String) async -> Bool
+    
     /**
      Performs a rollover operation on the storage.
 

--- a/Sources/RudderStackAnalytics/Storage/Storage.swift
+++ b/Sources/RudderStackAnalytics/Storage/Storage.swift
@@ -80,6 +80,13 @@ protocol EventStorage {
      */
     @discardableResult
     func remove(batchReference: String) async -> Bool
+
+    /**
+     Removes all batches associated with the given reference from the storage.
+
+     - Parameter batchReference: The reference of the batches to be removed.
+     */
+    func removeAll(batchReference: String) async
     
     /**
      Performs a rollover operation on the storage.

--- a/Sources/RudderStackAnalytics/Storage/Storage.swift
+++ b/Sources/RudderStackAnalytics/Storage/Storage.swift
@@ -83,6 +83,8 @@ protocol EventStorage {
 
     /**
      Removes all batches associated with the current write key.
+
+     Note: This operation is irreversible and will permanently delete all associated events.
      */
     func removeAll() async
     

--- a/Sources/RudderStackAnalytics/Storage/Storage.swift
+++ b/Sources/RudderStackAnalytics/Storage/Storage.swift
@@ -84,7 +84,7 @@ protocol EventStorage {
     /**
      Removes all batches associated with the current write key.
 
-     Note: This operation is irreversible and will permanently delete all associated events.
+     **Note**: It is recommended to use this API during shutdown to ensure storage is not removed abruptly, which could lead to unexpected errors.
      */
     func removeAll() async
     

--- a/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
@@ -16,6 +16,7 @@ protocol DataStore {
     func retain(value: String) async
     func retrieve() async -> [EventDataItem]
     func remove(reference: String) async -> Bool
+    func removeAll(reference: String) async
     func rollover() async
 }
 

--- a/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
@@ -46,6 +46,7 @@ struct DataStoreConstants {
     static let memoryIndex = "rudderstack.event.memory.index."
     static let fileIndex = "rudderstack.event.file.index."
     static let fileNameSeparator: String = "-"
+    static let referenceSeparator: String = "-"
     static let fileType = "tmp"
     static let fileBatchPrefix = "{\"batch\":["
     static let fileBatchSentAtSuffix = "],\"sentAt\":\""

--- a/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
@@ -16,7 +16,7 @@ protocol DataStore {
     func retain(value: String) async
     func retrieve() async -> [EventDataItem]
     func remove(reference: String) async -> Bool
-    func removeAll(reference: String) async
+    func removeAll() async
     func rollover() async
 }
 

--- a/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DataStore.swift
@@ -45,8 +45,7 @@ struct DataStoreConstants {
     
     static let memoryIndex = "rudderstack.event.memory.index."
     static let fileIndex = "rudderstack.event.file.index."
-    static let fileNameSeparator: String = "-"
-    static let referenceSeparator: String = "-"
+    static let referenceSeparator: String = "~"
     static let fileType = "tmp"
     static let fileBatchPrefix = "{\"batch\":["
     static let fileBatchSentAtSuffix = "],\"sentAt\":\""

--- a/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
@@ -61,7 +61,11 @@ final actor DiskStore {
         return FileManager.contentsOf(directory: directory.path)
             .filter { $0.pathExtension.isEmpty }
             .map { directory.appendingPathComponent($0.lastPathComponent).path }
-            .sorted { (Int($0) ?? 0) < (Int($1) ?? 0) }
+            .sorted {
+                let lhsIndex = Int(URL(fileURLWithPath: $0).lastPathComponent) ?? 0
+                let rhsIndex = Int(URL(fileURLWithPath: $1).lastPathComponent) ?? 0
+                return lhsIndex < rhsIndex
+            }
     }
     
     private func removeItems(using reference: String) {

--- a/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
@@ -70,8 +70,7 @@ final actor DiskStore {
     
     private func removeItems(using reference: String) {
         let folderPath = (reference as NSString).deletingLastPathComponent
-        let result = FileManager.delete(item: folderPath)
-        result ? LoggerAnalytics.debug(log: "Successfully removed folder: \(folderPath)") : LoggerAnalytics.debug(log: "Folder does not exist: \(folderPath)")
+        FileManager.delete(item: folderPath)
     }
 }
 

--- a/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
@@ -13,15 +13,20 @@ import Foundation
 final actor DiskStore {
     
     let writeKey: String
-    let fileStorageURL: URL = FileManager.eventStorageURL
+    var fileStorageURL: URL
     private let keyValueStore: KeyValueStore
     
     init(writeKey: String) {
         self.writeKey = writeKey
+        self.fileStorageURL = FileManager.eventStorageURL.appendingPathComponent(self.writeKey)
         self.keyValueStore = KeyValueStore(writeKey: writeKey)
     }
     
     private func store(event: String) {
+        
+        // Create directory if it doesn't exist
+        FileManager.createDirectoryIfNeeded(at: self.fileStorageURL)
+        
         var currentFilePath = self.currentFileURL.path
         var newFile = false
         if !FileManager.default.fileExists(atPath: currentFilePath) {
@@ -54,13 +59,15 @@ final actor DiskStore {
     private func collectFiles() -> [String] {
         let directory = self.currentFileURL.deletingLastPathComponent()
         return FileManager.contentsOf(directory: directory.path)
-            .filter { $0.lastPathComponent.contains(self.writeKey) && $0.pathExtension.isEmpty }
+            .filter { $0.pathExtension.isEmpty }
             .map { directory.appendingPathComponent($0.lastPathComponent).path }
-            .sorted {
-                let idx1 = Int($0.components(separatedBy: DataStoreConstants.fileNameSeparator).last ?? .empty) ?? 0
-                let idx2 = Int($1.components(separatedBy: DataStoreConstants.fileNameSeparator).last ?? .empty) ?? 0
-                return idx1 < idx2
-            }
+            .sorted { (Int($0) ?? 0) < (Int($1) ?? 0) }
+    }
+    
+    private func removeItems(using reference: String) {
+        let folderPath = (reference as NSString).deletingLastPathComponent
+        let result = FileManager.delete(item: folderPath)
+        result ? LoggerAnalytics.debug(log: "Successfully removed folder: \(folderPath)") : LoggerAnalytics.debug(log: "Folder does not exist: \(folderPath)")
     }
 }
 
@@ -78,7 +85,7 @@ extension DiskStore {
     }
     
     private var currentFileURL: URL {
-        return self.fileStorageURL.appendingPathComponent(self.writeKey + "\(DataStoreConstants.fileNameSeparator)\(self.currentFileIndex)").appendingPathExtension(DataStoreConstants.fileType)
+        return self.fileStorageURL.appendingPathComponent( "\(self.currentFileIndex)").appendingPathExtension(DataStoreConstants.fileType)
     }
     
     private func incrementFileIndex() {
@@ -136,7 +143,14 @@ extension DiskStore: DataStore {
     
     func remove(reference filePath: String) async -> Bool {
         await withCheckedContinuation { continuation in
-            continuation.resume(returning: FileManager.delete(file: filePath))
+            continuation.resume(returning: FileManager.delete(item: filePath))
+        }
+    }
+    
+    func removeAll(reference: String) async {
+        await withCheckedContinuation { continuation in
+            self.removeItems(using: reference)
+            continuation.resume()
         }
     }
     

--- a/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/DiskStore.swift
@@ -68,8 +68,8 @@ final actor DiskStore {
             }
     }
     
-    private func removeItems(using reference: String) {
-        let folderPath = (reference as NSString).deletingLastPathComponent
+    private func removeAllItems() {
+        let folderPath = self.currentFileURL.deletingLastPathComponent().path
         FileManager.delete(item: folderPath)
     }
 }
@@ -150,9 +150,9 @@ extension DiskStore: DataStore {
         }
     }
     
-    func removeAll(reference: String) async {
+    func removeAll() async {
         await withCheckedContinuation { continuation in
-            self.removeItems(using: reference)
+            self.removeAllItems()
             continuation.resume()
         }
     }

--- a/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
@@ -89,12 +89,12 @@ final actor MemoryStore {
  Helper functions for managing batch references.
  */
 extension MemoryStore {
-    func appendWriteKey(with reference: String) -> String {
+    private func appendWriteKey(with reference: String) -> String {
         guard !reference.hasPrefix(self.writeKey) else { return reference }
         return self.writeKey + DataStoreConstants.referenceSeparator + reference
     }
     
-    func recoverWriteKey(from reference: String) -> String? {
+    private func recoverWriteKey(from reference: String) -> String? {
         return reference.components(separatedBy: DataStoreConstants.referenceSeparator).first
     }
 }

--- a/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
@@ -78,10 +78,9 @@ final actor MemoryStore {
         return true
     }
     
-    private func removeItems(using reference: String) {
-        guard let writeKey = self.recoverWriteKey(from: reference) else { return }
+    private func removeAllItems() {
         self.dataItems.removeAll { $0.reference.hasPrefix(writeKey + DataStoreConstants.referenceSeparator) }
-        LoggerAnalytics.debug(log: "Items removed related to reference: \(reference)")
+        LoggerAnalytics.debug(log: "Items removed related to reference: \(writeKey)")
     }
 }
 
@@ -92,10 +91,6 @@ extension MemoryStore {
     private func appendWriteKey(with reference: String) -> String {
         guard !reference.hasPrefix(self.writeKey) else { return reference }
         return self.writeKey + DataStoreConstants.referenceSeparator + reference
-    }
-    
-    private func recoverWriteKey(from reference: String) -> String? {
-        return reference.components(separatedBy: DataStoreConstants.referenceSeparator).first
     }
 }
 
@@ -143,9 +138,9 @@ extension MemoryStore: DataStore {
         }
     }
     
-    func removeAll(reference: String) async {
+    func removeAll() async {
         await withCheckedContinuation { continuation in
-            self.removeItems(using: reference)
+            self.removeAllItems()
             continuation.resume()
         }
     }

--- a/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
+++ b/Sources/RudderStackAnalytics/Storage/Store/MemoryStore.swift
@@ -80,7 +80,7 @@ final actor MemoryStore {
     
     private func removeItems(using reference: String) {
         guard let writeKey = self.recoverWriteKey(from: reference) else { return }
-        self.dataItems.removeAll { $0.reference.hasPrefix(writeKey) }
+        self.dataItems.removeAll { $0.reference.hasPrefix(writeKey + DataStoreConstants.referenceSeparator) }
         LoggerAnalytics.debug(log: "Items removed related to reference: \(reference)")
     }
 }

--- a/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
+++ b/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
@@ -62,7 +62,7 @@ final class EventQueueTests: XCTestCase {
         // Cleanup
         let dataItems = await mockAnalytics.configuration.storage.read().dataItems
         for item in dataItems {
-            await mockAnalytics.configuration.storage.remove(eventReference: item.reference)
+            await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -114,7 +114,7 @@ final class EventQueueTests: XCTestCase {
         // Cleanup
         let dataItems = await mockAnalytics.configuration.storage.read().dataItems
         for item in dataItems {
-            await mockAnalytics.configuration.storage.remove(eventReference: item.reference)
+            await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
         }
     }
 }

--- a/Tests/RudderStackAnalyticsTests/EventQueue/EventUploadErrorTests.swift
+++ b/Tests/RudderStackAnalyticsTests/EventQueue/EventUploadErrorTests.swift
@@ -100,7 +100,7 @@ extension EventUploadErrorTests {
         guard let analytics = mockAnalytics else { return }
         let dataItems = await analytics.configuration.storage.read().dataItems
         for item in dataItems {
-            await analytics.configuration.storage.remove(eventReference: item.reference)
+            await analytics.configuration.storage.remove(batchReference: item.reference)
         }
     }
 }

--- a/Tests/RudderStackAnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
+++ b/Tests/RudderStackAnalyticsTests/PluginTests/LifecycleTrackingPluginTests.swift
@@ -110,7 +110,7 @@ final class LifecycleTrackingPluginTests: XCTestCase {
         let eventNames = batchData.compactMap { $0["event"] as? String }
         
         for item in dataItems {
-            await analyticsMock.configuration.storage.remove(eventReference: item.reference)
+            await analyticsMock.configuration.storage.remove(batchReference: item.reference)
         }
 
         return eventNames

--- a/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
+++ b/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
@@ -55,7 +55,7 @@ extension RudderStackAnalyticsTests {
         XCTAssertFalse(dataItems.isEmpty)
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -68,7 +68,7 @@ extension RudderStackAnalyticsTests {
         XCTAssertFalse(dataItems.isEmpty)
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -81,7 +81,7 @@ extension RudderStackAnalyticsTests {
         XCTAssertFalse(dataItems.isEmpty)
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -93,7 +93,7 @@ extension RudderStackAnalyticsTests {
         let dataItems = await client.configuration.storage.read().dataItems
         XCTAssertFalse(dataItems.isEmpty)
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -203,7 +203,7 @@ extension RudderStackAnalyticsTests {
         }
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
     
@@ -229,7 +229,7 @@ extension RudderStackAnalyticsTests {
         XCTAssertTrue(lastEvent["event"] as? String == "New Event Name", "Event name should be modified by the plugin")
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
 
@@ -256,7 +256,7 @@ extension RudderStackAnalyticsTests {
         XCTAssertTrue(lastEvent["event"] as? String == "Original Event", "Event name should remain unchanged after plugin removal")
         
         for item in dataItems {
-            await client.configuration.storage.remove(eventReference: item.reference)
+            await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
 }

--- a/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
+++ b/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
@@ -155,11 +155,9 @@ extension StorageModuleTests {
         
         let resultItems = await storage.read().dataItems
         XCTAssertFalse(resultItems.isEmpty)
-        
-        guard let firstItem = resultItems.first else { XCTFail(); return }
-        
+                
         // Remove all events using removeAll method
-        await storage.removeAll(batchReference: firstItem.reference)
+        await storage.removeAll()
         
         let dataItemsAfterRemoval = await storage.read().dataItems
         XCTAssertTrue(dataItemsAfterRemoval.isEmpty)
@@ -237,11 +235,9 @@ extension StorageModuleTests {
         
         let resultItems = await storage.read().dataItems
         XCTAssertFalse(resultItems.isEmpty)
-        
-        guard let firstItem = resultItems.first else { XCTFail(); return }
-        
+                
         // Remove all events using removeAll method
-        await storage.removeAll(batchReference: firstItem.reference)
+        await storage.removeAll()
         
         let dataItemsAfterRemoval = await storage.read().dataItems
         XCTAssertTrue(dataItemsAfterRemoval.isEmpty)

--- a/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
+++ b/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
@@ -142,6 +142,29 @@ extension StorageModuleTests {
         XCTAssertTrue(isRemoved)
     }
     
+    func test_remove_all_event_disk() async {
+        guard let storage = self.analytics_disk?.configuration.storage, let eventJson = MockProvider.simpleTrackEvent.jsonString else { XCTFail(); return }
+        
+        // Write multiple events
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        
+        let resultItems = await storage.read().dataItems
+        XCTAssertFalse(resultItems.isEmpty)
+        
+        guard let firstItem = resultItems.first else { XCTFail(); return }
+        
+        // Remove all events using removeAll method
+        await storage.removeAll(batchReference: firstItem.reference)
+        
+        let dataItemsAfterRemoval = await storage.read().dataItems
+        XCTAssertTrue(dataItemsAfterRemoval.isEmpty)
+    }
+    
     func test_rollover_event_disk() async {
         guard let storage = self.analytics_disk?.configuration.storage, let eventJson = MockProvider.simpleTrackEvent.jsonString else { XCTFail(); return }
         
@@ -199,6 +222,29 @@ extension StorageModuleTests {
         
         let dataItems = await storage.read().dataItems
         XCTAssertTrue(dataItems.isEmpty)
+    }
+    
+    func test_remove_all_event_memory() async {
+        guard let storage = self.analytics_memory?.configuration.storage, let eventJson = MockProvider.simpleTrackEvent.jsonString else { XCTFail(); return }
+        
+        // Write multiple events
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        await storage.write(event: eventJson)
+        await storage.rollover()
+        
+        let resultItems = await storage.read().dataItems
+        XCTAssertFalse(resultItems.isEmpty)
+        
+        guard let firstItem = resultItems.first else { XCTFail(); return }
+        
+        // Remove all events using removeAll method
+        await storage.removeAll(batchReference: firstItem.reference)
+        
+        let dataItemsAfterRemoval = await storage.read().dataItems
+        XCTAssertTrue(dataItemsAfterRemoval.isEmpty)
     }
     
     func test_rollover_event_memory() async {

--- a/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
+++ b/Tests/RudderStackAnalyticsTests/StorageModuleTests.swift
@@ -138,7 +138,7 @@ extension StorageModuleTests {
         
         guard let item = result.first else { XCTFail(); return }
         
-        let isRemoved = await storage.remove(eventReference: item.reference)
+        let isRemoved = await storage.remove(batchReference: item.reference)
         XCTAssertTrue(isRemoved)
     }
     
@@ -149,7 +149,7 @@ extension StorageModuleTests {
         await storage.rollover()
         let files = await storage.read().dataItems
         for file in files {
-            await storage.remove(eventReference: file.reference)
+            await storage.remove(batchReference: file.reference)
         }
         
         await storage.write(event: eventJson)
@@ -194,7 +194,7 @@ extension StorageModuleTests {
         
         let resultItems = await storage.read().dataItems
         for item in resultItems {
-            await storage.remove(eventReference: item.reference)
+            await storage.remove(batchReference: item.reference)
         }
         
         let dataItems = await storage.read().dataItems
@@ -207,7 +207,7 @@ extension StorageModuleTests {
         await storage.rollover()
         let resultItems1 = await storage.read().dataItems
         for item in resultItems1 {
-            await storage.remove(eventReference: item.reference)
+            await storage.remove(batchReference: item.reference)
         }
 
         await storage.write(event: eventJson)


### PR DESCRIPTION
## Description
This PR implements a new storage API that enhances batch file management with write key-based isolation and bulk removal capabilities. The changes introduce a `removeAll` method for efficient cleanup of all batches associated with a specific write key, along with improved file organization and better semantic clarity by renaming methods from event-based to batch-based terminology.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Storage Protocol Enhancement**: Added `removeAll(batchReference:)` method to `EventStorage` protocol for bulk batch removal operations
- **API Method Renaming**: Renamed `remove(eventReference:)` to `remove(batchReference:)` across all storage implementations for better semantic clarity
- **Write Key Directory Structure**: Modified `DiskStore` to organize files under write key-specific subdirectories (`{base_path}/{writeKey}/`)
- **File Management Improvements**: 
  - Added `createDirectoryIfNeeded(at:)` helper method for safe directory creation
  - Enhanced `delete(item:)` method to handle both files and directories
  - Simplified file naming convention by removing write key from filenames (now index-based only)
- **Memory Store Enhancements**:
  - Implemented write key prefixing for batch references to ensure data isolation
  - Added helper methods `appendWriteKey(with:)` and `recoverWriteKey(from:)` for reference management
  - Added `removeAll(reference:)` implementation for memory-based bulk removal
- **Constants Addition**: Added `referenceSeparator` constant for consistent write key reference formatting
- **Comprehensive Test Updates**: Updated all test files to use the new `remove(batchReference:)` API and added test coverage for `removeAll` functionality

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Disk Storage Testing**: 
   - Verify that files are created in write key-specific directories
   - Test individual batch removal using `remove(batchReference:)`
   - Test bulk removal using `removeAll(batchReference:)` 
   - Confirm proper directory cleanup after bulk removal

2. **Memory Storage Testing**:
   - Verify write key prefixing in batch references
   - Test isolation between different write keys
   - Test bulk removal functionality for memory storage

## Breaking Changes
- **Method Signature Change**: `remove(eventReference: String)` has been renamed to `remove(batchReference: String)`
- **Directory Structure Change**: Files are now organized under write key-specific subdirectories instead of the shared directory

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is a backend storage API enhancement without UI changes.

## Additional Context
- **Performance Impact**: The new directory structure and write key isolation provide better organization and should improve performance for applications using multiple write keys
- **Security Enhancement**: Write key isolation prevents cross-contamination of data between different analytics instances
- **Future Compatibility**: This change sets the foundation for better multi-tenant support and more efficient batch management

### File Organization Changes:
**Before**: `rudder/analytics/events/{writeKey}-{index}.tmp`  
**After**: `rudder/analytics/events/{writeKey}/{index}.tmp`

### API Changes:
```swift
// Old API
func remove(eventReference: String) async -> Bool

// New API  
func remove(batchReference: String) async -> Bool
func removeAll(batchReference: String) async
```
