### PR TITLE
feat: implement HTTP 404 error handling for batch upload requests

### DIFF
--- a/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
@@ -95,7 +95,6 @@ extension EventUploader: TypeIdentifiable {
         
         // TODO: - Handle batch upload errors (use below tickets)
 
-        // https://linear.app/rudderstack/issue/SDK-3722/handle-status-code-404-from-batch-upload-request
         // https://linear.app/rudderstack/issue/SDK-3726/introduce-retry-logic-in-batch-upload-flow
         
         if let nonRetryableError = error as? NonRetryableEventUploadError {
@@ -109,7 +108,6 @@ extension EventUploader: TypeIdentifiable {
                 self.analytics.shutdown()
                 await self.storage.removeAll()
                 
-            
             case .error404:
                 LoggerAnalytics.error(log: "\(className): \(nonRetryableError.formatStatusCodeMessage). " + "Stopping the events upload process until the source is enabled again.")
                 self.stop()
@@ -118,9 +116,6 @@ extension EventUploader: TypeIdentifiable {
             case .error413:
                 LoggerAnalytics.error(log: "\(className): \(nonRetryableError.formatStatusCodeMessage). " + "Request failed: Payload size exceeds the maximum allowed limit.")
                 await self.deleteBatchFile(reference)
-                
-            default:
-                break
             }
         }
     }

--- a/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
@@ -95,7 +95,6 @@ extension EventUploader: TypeIdentifiable {
         
         // TODO: - Handle batch upload errors (use below tickets)
         // https://linear.app/rudderstack/issue/SDK-3724/handle-status-code-401-from-batch-upload-request
-        // https://linear.app/rudderstack/issue/SDK-3722/handle-status-code-404-from-batch-upload-request
         // https://linear.app/rudderstack/issue/SDK-3726/introduce-retry-logic-in-batch-upload-flow
         
         if let nonRetryableError = error as? NonRetryableEventUploadError {
@@ -103,7 +102,12 @@ extension EventUploader: TypeIdentifiable {
             case .error400:
                 LoggerAnalytics.error(log: "\(className): \(nonRetryableError.formatStatusCodeMessage). Invalid request: Missing or malformed body. " + "Ensure the payload is a valid JSON and includes either 'anonymousId' or 'userId' properties")
                 await self.deleteBatchFile(reference)
-                
+            
+            case .error404:
+                LoggerAnalytics.error(log: "\(className): \(nonRetryableError.formatStatusCodeMessage). " + "Stopping the events upload process until the source is enabled again.")
+                self.stop()
+                // TODO: - When working on SourceConfig items, implement logic to wait for source to be enabled again.
+
             case .error413:
                 LoggerAnalytics.error(log: "\(className): \(nonRetryableError.formatStatusCodeMessage). " + "Request failed: Payload size exceeds the maximum allowed limit.")
                 await self.deleteBatchFile(reference)


### PR DESCRIPTION
## Description
This PR implements handling for HTTP 404 status codes in the batch upload process. When a 404 error occurs during event upload, it indicates that the source is disabled or doesn't exist. The implementation stops the event uploader process while preserving the events in storage for future retry when the source becomes available again.

### Note:
- A TODO comment has been added to handle the logic for waiting until a source is re-enabled when working with SourceConfig items, since this functionality is not yet fully implemented.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Added 404 error handling in `EventUploader.swift`**: When a `NonRetryableEventUploadError.error404` occurs, the uploader stops the upload process and logs an appropriate error message
- **Event preservation**: Unlike 400 and 413 errors, 404 errors do not delete the batch file from storage, allowing for retry when the source is enabled again
- **Uploader state management**: The uploader calls `self.stop()` to halt the upload process until the source configuration is updated
- **Comprehensive test coverage**: Added `test_uploadBatchHandles404Error()` to verify correct behavior including:
  - Uploader stops correctly (upload channel closes)
  - Events are preserved in storage (not deleted like 400/413 errors)
  - Analytics remains active (unlike 401 errors)
- **Code cleanup**: Removed the completed SDK-3722 ticket reference from the TODO comments

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Unit Tests**: Run the test suite, specifically `EventUploadErrorTests.test_uploadBatchHandles404Error()`
2. **Manual Testing**: 
   - Configure the SDK with an invalid/disabled source
   - Send events to trigger batch upload
   - Verify that events are preserved in storage
   - Verify that the uploader stops processing
   - Check logs for appropriate error messages

The test verifies:
- Mock HTTP session returns 404 status code
- Events are stored and uploader processes them
- Upload channel closes (indicating uploader stopped)
- Events remain in storage for future retry
- Analytics instance remains active

## Breaking Changes
None. This is a backwards-compatible enhancement to error handling.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is a backend logic change without UI components.

## Additional Context
The implementation follows the same pattern as other error handlers (400, 413) but with different behavior:
- **400 & 413 errors**: Delete batch and continue (permanent failures)
- **404 errors**: Stop uploader but preserve current batch (temporary source unavailability)
- **Future 401 errors**: Will likely stop analytics entirely (authentication issues)
