### PR TITLE
feat: add user agent plugin examples with dynamic and static implementations

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */; };
 		539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */; };
 		539301CA2E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */; };
+		539301CC2E6AFBA000DAEAD1 /* StaticUserAgentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301CB2E6AFBA000DAEAD1 /* StaticUserAgentPluginTests.swift */; };
 		53DEA72D2E03EBB900D6C371 /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; };
 		53DEA72E2E03EBB900D6C371 /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -88,6 +89,7 @@
 		5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPlugin.swift; sourceTree = "<group>"; };
 		539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPluginTests.swift; sourceTree = "<group>"; };
 		539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticUserAgentPlugin.swift; sourceTree = "<group>"; };
+		539301CB2E6AFBA000DAEAD1 /* StaticUserAgentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticUserAgentPluginTests.swift; sourceTree = "<group>"; };
 		53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -197,6 +199,7 @@
 				535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */,
 				535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */,
 				539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */,
+				539301CB2E6AFBA000DAEAD1 /* StaticUserAgentPluginTests.swift */,
 			);
 			path = SwiftUIExampleTests;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 				535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */,
 				539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */,
 				535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */,
+				539301CC2E6AFBA000DAEAD1 /* StaticUserAgentPluginTests.swift in Sources */,
 				535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */; };
 		539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */; };
 		539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */; };
+		539301CA2E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */; };
 		53DEA72D2E03EBB900D6C371 /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; };
 		53DEA72E2E03EBB900D6C371 /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -86,6 +87,7 @@
 		5383D2CE2D3EAC0C00291B00 /* SwiftUIExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUIExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPlugin.swift; sourceTree = "<group>"; };
 		539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPluginTests.swift; sourceTree = "<group>"; };
+		539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticUserAgentPlugin.swift; sourceTree = "<group>"; };
 		53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -143,6 +145,7 @@
 				535BB3D22E04642400E1DAB0 /* OptionPlugin.swift */,
 				535BB3D32E04642400E1DAB0 /* SetAnonymousIdPlugin.swift */,
 				535BB3D42E04642400E1DAB0 /* SetPushTokenPlugin.swift */,
+				539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */,
 				5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */,
 				5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */,
 			);
@@ -303,6 +306,7 @@
 			files = (
 				535BB3E52E04642400E1DAB0 /* SwiftUIExampleApp.swift in Sources */,
 				535BB3E62E04642400E1DAB0 /* AnalyticsManager.swift in Sources */,
+				539301CA2E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift in Sources */,
 				535BB3E72E04642400E1DAB0 /* SetPushTokenPlugin.swift in Sources */,
 				535BB3E82E04642400E1DAB0 /* CustomLogger.swift in Sources */,
 				535BB3E92E04642400E1DAB0 /* SetAnonymousIdPlugin.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F12E04643900E1DAB0 /* BluetoothInfoPluginTests.swift */; };
 		535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */; };
 		535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */; };
-		539301A02E69A5B000DAEAD1 /* UserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */; };
+		539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */; };
 		53DEA72D2E03EBB900D6C371 /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; };
 		53DEA72E2E03EBB900D6C371 /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -83,7 +83,7 @@
 		535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPushTokenPluginTests.swift; sourceTree = "<group>"; };
 		535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIAppTests.swift; sourceTree = "<group>"; };
 		5383D2CE2D3EAC0C00291B00 /* SwiftUIExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUIExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentPlugin.swift; sourceTree = "<group>"; };
+		5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPlugin.swift; sourceTree = "<group>"; };
 		53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -142,7 +142,7 @@
 				535BB3D32E04642400E1DAB0 /* SetAnonymousIdPlugin.swift */,
 				535BB3D42E04642400E1DAB0 /* SetPushTokenPlugin.swift */,
 				5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */,
-				5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */,
+				5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */,
 			);
 			path = CustomPlugins;
 			sourceTree = "<group>";
@@ -303,7 +303,7 @@
 				535BB3E72E04642400E1DAB0 /* SetPushTokenPlugin.swift in Sources */,
 				535BB3E82E04642400E1DAB0 /* CustomLogger.swift in Sources */,
 				535BB3E92E04642400E1DAB0 /* SetAnonymousIdPlugin.swift in Sources */,
-				539301A02E69A5B000DAEAD1 /* UserAgentPlugin.swift in Sources */,
+				539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */,
 				535BB3EA2E04642400E1DAB0 /* ContentView.swift in Sources */,
 				535BB3EB2E04642400E1DAB0 /* BluetoothInfoPlugin.swift in Sources */,
 				5328B86C2E3B48820051A202 /* EventFilteringPlugin.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */; };
 		535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */; };
 		539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */; };
+		539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */; };
 		53DEA72D2E03EBB900D6C371 /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; };
 		53DEA72E2E03EBB900D6C371 /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -84,6 +85,7 @@
 		535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIAppTests.swift; sourceTree = "<group>"; };
 		5383D2CE2D3EAC0C00291B00 /* SwiftUIExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUIExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPlugin.swift; sourceTree = "<group>"; };
+		539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPluginTests.swift; sourceTree = "<group>"; };
 		53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -191,6 +193,7 @@
 				535BB3F32E04643900E1DAB0 /* SetAnonymousIdPluginTests.swift */,
 				535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */,
 				535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */,
+				539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */,
 			);
 			path = SwiftUIExampleTests;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				535BB3F92E04643900E1DAB0 /* SetAnonymousIdPluginTests.swift in Sources */,
 				535BB3FA2E04643900E1DAB0 /* OptionPluginTests.swift in Sources */,
 				535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */,
+				539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */,
 				535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */,
 				535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */,
 			);

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F12E04643900E1DAB0 /* BluetoothInfoPluginTests.swift */; };
 		535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */; };
 		535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */; };
+		539301A02E69A5B000DAEAD1 /* UserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */; };
 		53DEA72D2E03EBB900D6C371 /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; };
 		53DEA72E2E03EBB900D6C371 /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -82,6 +83,7 @@
 		535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPushTokenPluginTests.swift; sourceTree = "<group>"; };
 		535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIAppTests.swift; sourceTree = "<group>"; };
 		5383D2CE2D3EAC0C00291B00 /* SwiftUIExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUIExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentPlugin.swift; sourceTree = "<group>"; };
 		53DEA72C2E03EBB900D6C371 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -140,6 +142,7 @@
 				535BB3D32E04642400E1DAB0 /* SetAnonymousIdPlugin.swift */,
 				535BB3D42E04642400E1DAB0 /* SetPushTokenPlugin.swift */,
 				5328B86B2E3B48820051A202 /* EventFilteringPlugin.swift */,
+				5393019F2E69A5B000DAEAD1 /* UserAgentPlugin.swift */,
 			);
 			path = CustomPlugins;
 			sourceTree = "<group>";
@@ -300,6 +303,7 @@
 				535BB3E72E04642400E1DAB0 /* SetPushTokenPlugin.swift in Sources */,
 				535BB3E82E04642400E1DAB0 /* CustomLogger.swift in Sources */,
 				535BB3E92E04642400E1DAB0 /* SetAnonymousIdPlugin.swift in Sources */,
+				539301A02E69A5B000DAEAD1 /* UserAgentPlugin.swift in Sources */,
 				535BB3EA2E04642400E1DAB0 /* ContentView.swift in Sources */,
 				535BB3EB2E04642400E1DAB0 /* BluetoothInfoPlugin.swift in Sources */,
 				5328B86C2E3B48820051A202 /* EventFilteringPlugin.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
@@ -61,7 +61,7 @@ extension DynamicUserAgentPlugin {
     /**
      Reads the User Agent string using a WKWebView instance.
      
-     - Returns: The User Agent string if available, otherwise nil.
+     - Returns: The User Agent string from WebKit's `navigator.userAgent` if available, otherwise nil.
      - Note: This method must be called on the main thread as `WKWebView` requires it.
      */
     

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  UserAgentPlugin.swift
+//  DynamicUserAgentPlugin.swift
 //  SwiftUIExampleApp
 //
 //  Created by Satheesh Kannan on 04/09/25.
@@ -12,18 +12,18 @@ import RudderStackAnalytics
 import WebKit
 #endif
 
-// MARK: - UserAgentPlugin
+// MARK: - DynamicUserAgentPlugin
 /**
  A plugin that adds User Agent information to the event payload.
  
  ## Usage:
  ```swift
  // Create and add the plugin
- let userAgentPlugin = UserAgentPlugin()
+ let userAgentPlugin = DynamicUserAgentPlugin()
  analytics.add(plugin: userAgentPlugin)
  ```
  */
-final class UserAgentPlugin: Plugin {
+final class DynamicUserAgentPlugin: Plugin {
     var pluginType: PluginType = .preProcess
     var analytics: Analytics?
     var userAgent: String?
@@ -55,7 +55,7 @@ final class UserAgentPlugin: Plugin {
 }
 
 // MARK: - UserAgent
-extension UserAgentPlugin {
+extension DynamicUserAgentPlugin {
     
     @MainActor
     func readUserAgent() async -> String? {

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
@@ -15,6 +15,7 @@ import WebKit
 // MARK: - DynamicUserAgentPlugin
 /**
  A plugin that dynamically adds User Agent information to the event payload.
+ Supported on iOS, macOS, and tvOS only (requires WebKit framework).
  
  ## Usage:
  ```swift

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
@@ -14,8 +14,8 @@ import WebKit
 
 // MARK: - DynamicUserAgentPlugin
 /**
- A plugin that adds User Agent information to the event payload.
- 
+ A plugin that dynamically adds User Agent information to the event payload.
+
  ## Usage:
  ```swift
  // Create and add the plugin
@@ -29,6 +29,7 @@ final class DynamicUserAgentPlugin: Plugin {
     var userAgent: String?
     
     init() {
+        // Read user agent on initialization on main thread
         Task { @MainActor [weak self] in
             guard let self else {
                 LoggerAnalytics.debug(log: "Failed to read user agent")
@@ -56,6 +57,13 @@ final class DynamicUserAgentPlugin: Plugin {
 
 // MARK: - UserAgent
 extension DynamicUserAgentPlugin {
+    
+    /**
+     Reads the User Agent string using a WKWebView instance.
+     
+     - Returns: The User Agent string if available, otherwise nil.
+     - Note: This method must be called on the main thread as `WKWebView` requires it.
+     */
     
     @MainActor
     func readUserAgent() async -> String? {

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/DynamicUserAgentPlugin.swift
@@ -43,7 +43,7 @@ final class DynamicUserAgentPlugin: Plugin {
     }
     
     func intercept(event: any Event) -> (any Event)? {
-        guard let userAgent = userAgent else { return event }
+        guard let userAgent else { return event }
         
         var updatedEvent = event
         var contextDict = updatedEvent.context?.rawDictionary ?? [:]

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
@@ -34,7 +34,7 @@ final class StaticUserAgentPlugin: Plugin {
     }
     
     func intercept(event: any Event) -> (any Event)? {
-        guard let userAgent = userAgent else { return event }
+        guard let userAgent else { return event }
         
         var updatedEvent = event
         var contextDict = updatedEvent.context?.rawDictionary ?? [:]

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
@@ -14,7 +14,7 @@ import UIKit
 
 // MARK: - StaticUserAgentPlugin
 /**
- A plugin that adds User Agent information to the event payload.
+ A plugin that add static User Agent information to the event payload.
  
  ## Usage:
  ```swift
@@ -48,6 +48,12 @@ final class StaticUserAgentPlugin: Plugin {
 // MARK: - UserAgent
 extension StaticUserAgentPlugin {
     
+    /**
+     Reads the User Agent string based on the current platform.
+     
+     - Returns: The User Agent string.
+     - Note: This method can be called from any thread.
+     */
     func readUserAgent() -> String {
         let appName = applicationName
         let separator = appName.isEmpty ? "" : " "

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
@@ -15,6 +15,7 @@ import UIKit
 // MARK: - StaticUserAgentPlugin
 /**
  A plugin that adds static User Agent information to the event payload.
+ Supported on all Apple platforms (iOS, macOS, tvOS, watchOS).
  
  ## Usage:
  ```swift

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
@@ -14,7 +14,7 @@ import UIKit
 
 // MARK: - StaticUserAgentPlugin
 /**
- A plugin that add static User Agent information to the event payload.
+ A plugin that adds static User Agent information to the event payload.
  
  ## Usage:
  ```swift

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/StaticUserAgentPlugin.swift
@@ -1,0 +1,115 @@
+//
+//  StaticUserAgentPlugin.swift
+//  SwiftUIExampleApp
+//
+//  Created by Satheesh Kannan on 04/09/25.
+//
+
+import Foundation
+import RudderStackAnalytics
+
+#if os(iOS)
+import UIKit
+#endif
+
+// MARK: - StaticUserAgentPlugin
+/**
+ A plugin that adds User Agent information to the event payload.
+ 
+ ## Usage:
+ ```swift
+ // Create and add the plugin
+ let userAgentPlugin = StaticUserAgentPlugin()
+ analytics.add(plugin: userAgentPlugin)
+ ```
+ */
+final class StaticUserAgentPlugin: Plugin {
+    var pluginType: PluginType = .preProcess
+    var analytics: Analytics?
+    var userAgent: String?
+    
+    func setup(analytics: Analytics) {
+        self.analytics = analytics
+        self.userAgent = self.readUserAgent()
+    }
+    
+    func intercept(event: any Event) -> (any Event)? {
+        guard let userAgent = userAgent else { return event }
+        
+        var updatedEvent = event
+        var contextDict = updatedEvent.context?.rawDictionary ?? [:]
+        contextDict["userAgent"] = userAgent
+        updatedEvent.context = contextDict.codableWrapped
+        
+        return updatedEvent
+    }
+}
+
+// MARK: - UserAgent
+extension StaticUserAgentPlugin {
+    
+    func readUserAgent() -> String {
+        let appName = applicationName
+        let separator = appName.isEmpty ? "" : " "
+        
+#if os(macOS)
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X \(osVersion)) AppleWebKit/\(webKitVersion) (KHTML, like Gecko)\(separator)\(appName)"
+        
+#elseif os(iOS) || targetEnvironment(macCatalyst)
+        let mobileAppName = appName.isEmpty ? "Mobile/\(mobileVersion)" : "\(appName) Mobile/\(mobileVersion)"
+        
+#if os(iOS)
+        // iOS user agent format
+        let cpuType = deviceModel == "iPhone" ? "iPhone" : "OS"
+        return "Mozilla/5.0 (\(deviceModel); CPU \(cpuType) \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko) \(mobileAppName)"
+#else
+        // Catalyst user agent format
+        return "Mozilla/5.0 (\(deviceModel); CPU OS \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko) \(mobileAppName)"
+#endif
+        
+#else
+        // watchOS, tvOS, etc.
+        return "Mozilla/5.0 (Apple; CPU OS \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko)\(separator)\(appName)"
+#endif
+    }
+}
+
+// MARK: - Helpers
+extension StaticUserAgentPlugin {
+    
+    private var osVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion)_\(version.minorVersion)_\(version.patchVersion)"
+    }
+    
+    private var applicationName: String {
+        guard let bundleInfo = Bundle.main.infoDictionary,
+              let appName = bundleInfo["CFBundleName"] as? String ?? bundleInfo["CFBundleDisplayName"] as? String,
+              let version = bundleInfo["CFBundleShortVersionString"] as? String else {
+            return ""
+        }
+        return "\(appName)/\(version)"
+    }
+    
+    private var deviceModel: String {
+#if os(iOS)
+        let model = UIDevice.current.model
+        
+        // Normalize device model names
+        if model.contains("iPhone") {
+            return "iPhone"
+        } else if model.contains("iPad") {
+            return "iPad"
+        } else {
+            // Default to iPad for unknown devices (Catalyst)
+            return "iPad"
+        }
+#else
+        return "iPad"
+#endif
+    }
+    
+    private var webKitVersion: String { "605.1.15" }
+    
+    private var mobileVersion: String { "15E148" }
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/UserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/UserAgentPlugin.swift
@@ -1,0 +1,8 @@
+//
+//  UserAgentPlugin.swift
+//  SwiftUIExampleApp
+//
+//  Created by Satheesh Kannan on 04/09/25.
+//
+
+import Foundation

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/UserAgentPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/UserAgentPlugin.swift
@@ -6,3 +6,151 @@
 //
 
 import Foundation
+import RudderStackAnalytics
+
+#if canImport(WebKit)
+import WebKit
+#endif
+
+#if os(iOS)
+import UIKit
+#endif
+
+// MARK: - UserAgentPlugin
+/**
+ A plugin that adds User Agent information to the event payload.
+ 
+ ## Usage:
+ ```swift
+ // Create and add the plugin
+ let userAgentPlugin = UserAgentPlugin()
+ analytics.add(plugin: userAgentPlugin)
+ ```
+ */
+final class UserAgentPlugin: Plugin {
+    var pluginType: PluginType = .preProcess
+    var analytics: Analytics?
+    var userAgent: String?
+    
+    init() {
+        Task { [weak self] in
+            guard let self else {
+                LoggerAnalytics.debug(log: "Failed to read user agent")
+                return
+            }
+            let ua = await self.readUserAgent()
+            LoggerAnalytics.debug(log: "User Agent: \(ua)")
+            self.userAgent = ua
+        }
+    }
+    
+    func setup(analytics: Analytics) {
+        self.analytics = analytics
+    }
+    
+    func intercept(event: any Event) -> (any Event)? {
+        guard let userAgent = userAgent else { return event }
+        
+        var updatedEvent = event
+        var contextDict = updatedEvent.context?.rawDictionary ?? [:]
+        contextDict["userAgent"] = userAgent
+        updatedEvent.context = contextDict.codableWrapped
+        
+        return updatedEvent
+    }
+}
+
+// MARK: - UserAgent
+extension UserAgentPlugin {
+    
+    @MainActor
+    private func readUserAgent() async -> String {
+#if canImport(WebKit)
+        do {
+            let webView = WKWebView(frame: .zero)
+            guard let ua = try await webView.evaluateJavaScript("navigator.userAgent") as? String,
+                  !ua.isEmpty else {  return preparedUserAgent() }
+            return ua
+            
+        } catch {
+            LoggerAnalytics.error(log: "Failed to read user agent", error: error)
+            return preparedUserAgent()
+        }
+#else
+        return preparedUserAgent()
+#endif
+    }
+    
+    private func preparedUserAgent() -> String {
+        let appName = applicationName
+        let separator = appName.isEmpty ? "" : " "
+        
+#if os(macOS)
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X \(osVersion)) AppleWebKit/\(webKitVersion) (KHTML, like Gecko)\(separator)\(appName)"
+        
+#elseif os(iOS)
+        let mobileAppName = appName.isEmpty ? "Mobile/\(mobileVersion)" : "\(appName) Mobile/\(mobileVersion)"
+        
+#if os(iOS)
+        // iOS user agent format
+        let cpuType = deviceModel == "iPhone" ? "iPhone" : "OS"
+        return "Mozilla/5.0 (\(deviceModel); CPU \(cpuType) \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko) \(mobileAppName)"
+#else
+        // Catalyst user agent format
+        return "Mozilla/5.0 (\(deviceModel); CPU OS \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko) \(mobileAppName)"
+#endif
+        
+#else
+        // watchOS, tvOS, etc.
+        return "Mozilla/5.0 (Apple; CPU OS \(osVersion) like Mac OS X) AppleWebKit/\(webKitVersion) (KHTML, like Gecko)\(separator)\(appName)"
+#endif
+    }
+}
+
+// MARK: - Helpers
+extension UserAgentPlugin {
+    
+    private var osVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion)_\(version.minorVersion)_\(version.patchVersion)"
+    }
+    
+    private var applicationName: String {
+        guard let bundleInfo = Bundle.main.infoDictionary,
+              let appName = bundleInfo["CFBundleName"] as? String ?? bundleInfo["CFBundleDisplayName"] as? String,
+              let version = bundleInfo["CFBundleShortVersionString"] as? String else {
+            return ""
+        }
+        return "\(appName)/\(version)"
+    }
+    
+    private var deviceModel: String {
+#if os(iOS)
+        let model = UIDevice.current.model
+        
+        // Normalize device model names
+        if model.contains("iPhone") {
+            return "iPhone"
+        } else if model.contains("iPad") {
+            return "iPad"
+        } else {
+            // Default to iPad for unknown devices (Catalyst)
+            return "iPad"
+        }
+#else
+        return "iPad"
+#endif
+    }
+    
+    private var webKitVersion: String {
+        // Try to get actual WebKit version from bundle first
+        if let webKitBundle = Bundle(identifier: "com.apple.WebKit"),
+           let version = webKitBundle.infoDictionary?["CFBundleShortVersionString"] as? String {
+            return version
+        }
+        
+        return "605.1.15"
+    }
+    
+    private var mobileVersion: String { "15E148" }
+}

--- a/Examples/SwiftUIExample/SwiftUIExampleTests/DynamicUserAgentPluginTests.swift
+++ b/Examples/SwiftUIExample/SwiftUIExampleTests/DynamicUserAgentPluginTests.swift
@@ -1,0 +1,159 @@
+//
+//  DynamicUserAgentPluginTests.swift
+//  SwiftUIExampleAppTests
+//
+//  Created by Satheesh Kannan on 05/09/25.
+//
+
+import Testing
+import RudderStackAnalytics
+@testable import SwiftUIExampleApp
+
+struct DynamicUserAgentPluginTests {
+    
+    @Test
+    func userAgent_isInjected_whenUserAgentIsAvailable() {
+        given("a UserAgentPlugin with userAgent set and event with no userAgent context") {
+            let plugin = DynamicUserAgentPlugin()
+            let event = MockEvent()
+            
+            // Directly set userAgent to test the intercept logic
+            plugin.userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+            
+            when("the plugin intercepts the event") {
+                let result = plugin.intercept(event: event)
+
+                then("it should inject the user agent into the context") {
+                    guard let contextDict = result?.context?.rawDictionary,
+                          let userAgent = contextDict["userAgent"] as? String else {
+                        #expect(Bool(false), "Expected userAgent to exist in context")
+                        return
+                    }
+                    #expect(!userAgent.isEmpty, "Expected userAgent to not be empty")
+                    #expect(userAgent.contains("Mozilla/5.0"), "Expected userAgent to contain Mozilla/5.0")
+                    #expect(userAgent.contains("iPhone"), "Expected userAgent to contain iPhone")
+                }
+            }
+        }
+    }
+
+    @Test
+    func userAgent_replacesExistingUserAgent_inContext() {
+        given("a UserAgentPlugin with userAgent set and event with existing userAgent") {
+            let plugin = DynamicUserAgentPlugin()
+            let event = MockEvent()
+            let newUserAgent = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+            
+            plugin.userAgent = newUserAgent
+            event.context = [
+                "userAgent": "old-user-agent",
+                "app": ["name": "TestApp"]
+            ].codableWrapped
+            
+            when("the plugin intercepts the event") {
+                let result = plugin.intercept(event: event)
+
+                then("it should replace the existing userAgent and preserve other fields") {
+                    guard let contextDict = result?.context?.rawDictionary else {
+                        #expect(Bool(false), "Expected context to exist")
+                        return
+                    }
+                    
+                    let userAgent = contextDict["userAgent"] as? String
+                    #expect(userAgent == newUserAgent, "Expected userAgent to be replaced with new value")
+                    #expect(userAgent != "old-user-agent", "Expected userAgent to not be the old value")
+                    
+                    let appContext = contextDict["app"] as? [String: Any]
+                    #expect(appContext?["name"] as? String == "TestApp", "Expected app context to be preserved")
+                }
+            }
+        }
+    }
+
+    @Test
+    func userAgent_returnsOriginalEvent_whenUserAgentNotAvailable() {
+        given("a UserAgentPlugin with no userAgent available") {
+            let plugin = DynamicUserAgentPlugin()
+            let event = MockEvent()
+            event.context = [
+                "app": ["name": "TestApp"]
+            ].codableWrapped
+            // Ensure userAgent is nil (it starts as nil anyway)
+            plugin.userAgent = nil
+
+            when("the plugin intercepts the event") {
+                let result = plugin.intercept(event: event)
+
+                then("it should return the original event unchanged") {
+                    guard let contextDict = result?.context?.rawDictionary else {
+                        #expect(Bool(false), "Expected the same event instance to be returned")
+                        return
+                    }
+                    
+                    // Verify no userAgent was added to context
+                    let userAgent = contextDict["userAgent"]
+                    #expect(userAgent == nil, "Expected no userAgent to be added when userAgent is nil")
+                }
+            }
+        }
+    }
+    
+    @Test
+    func userAgent_preservesOtherContextFields_whenAdding() {
+        given("a UserAgentPlugin and event with existing context fields") {
+            let plugin = DynamicUserAgentPlugin()
+            let event = MockEvent()
+            
+            plugin.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15"
+            event.context = [
+                "device": ["model": "iPhone", "id": "device123"],
+                "app": ["name": "TestApp", "version": "1.0"],
+                "library": ["name": "RudderStack", "version": "2.0"]
+            ].codableWrapped
+            
+            when("the plugin intercepts the event") {
+                let result = plugin.intercept(event: event)
+
+                then("it should add userAgent and preserve all existing context fields") {
+                    guard let contextDict = result?.context?.rawDictionary else {
+                        #expect(Bool(false), "Expected context to exist")
+                        return
+                    }
+                    
+                    // Check userAgent was added
+                    let userAgent = contextDict["userAgent"] as? String
+                    #expect(userAgent?.contains("Mozilla/5.0") == true, "Expected userAgent to be added")
+                    
+                    // Check existing fields are preserved
+                    let deviceContext = contextDict["device"] as? [String: Any]
+                    #expect(deviceContext?["model"] as? String == "iPhone", "Expected device model to be preserved")
+                    #expect(deviceContext?["id"] as? String == "device123", "Expected device id to be preserved")
+                    
+                    let appContext = contextDict["app"] as? [String: Any]
+                    #expect(appContext?["name"] as? String == "TestApp", "Expected app name to be preserved")
+                    #expect(appContext?["version"] as? String == "1.0", "Expected app version to be preserved")
+                    
+                    let libraryContext = contextDict["library"] as? [String: Any]
+                    #expect(libraryContext?["name"] as? String == "RudderStack", "Expected library name to be preserved")
+                    #expect(libraryContext?["version"] as? String == "2.0", "Expected library version to be preserved")
+                }
+            }
+        }
+    }
+    
+   @Test @MainActor
+   func readUserAgent_returnsNonEmptyString() async {
+       let plugin = DynamicUserAgentPlugin()
+       guard let userAgent = await plugin.readUserAgent() else {
+           #expect(Bool(false), "Expected userAgent to not be nil")
+           return
+       }
+       
+       #expect(!userAgent.isEmpty, "Expected userAgent to not be empty")
+       #expect(userAgent.contains("Mozilla/5.0"), "Expected userAgent to contain Mozilla/5.0")
+       #expect(userAgent.contains("AppleWebKit"), "Expected userAgent to contain AppleWebKit")
+   }
+}
+
+
+

--- a/Examples/SwiftUIExample/SwiftUIExampleTests/DynamicUserAgentPluginTests.swift
+++ b/Examples/SwiftUIExample/SwiftUIExampleTests/DynamicUserAgentPluginTests.swift
@@ -143,8 +143,7 @@ struct DynamicUserAgentPluginTests {
     
    @Test @MainActor
    func readUserAgent_returnsNonEmptyString() async {
-       let plugin = DynamicUserAgentPlugin()
-       guard let userAgent = await plugin.readUserAgent() else {
+       guard let userAgent = await DynamicUserAgentPlugin.readUserAgent() else {
            #expect(Bool(false), "Expected userAgent to not be nil")
            return
        }


### PR DESCRIPTION
## Description
This PR introduces two complementary User Agent plugin implementations for the RudderStack Swift SDK, demonstrating different approaches to collecting and adding User Agent information to event payloads:

1. **DynamicUserAgentPlugin**: Uses WebKit's `navigator.userAgent` to dynamically fetch the real browser User Agent string
2. **StaticUserAgentPlugin**: Generates platform-appropriate User Agent strings based on device and OS information

Both plugins automatically inject User Agent data into event context during preprocessing, providing developers with comprehensive examples of how to extend the RudderStack SDK with custom plugins that enhance event data.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `DynamicUserAgentPlugin` that uses WebKit JavaScript evaluation to get authentic User Agent strings
  - Implements async initialization with `@MainActor` isolation for WebKit requirements
  - Uses `WKWebView` to execute `navigator.userAgent` JavaScript
  - Gracefully handles WebKit unavailability or evaluation failures by returning nil
  - Automatically reads User Agent on plugin initialization in background task
  - User agent value: _Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148_

- Added `StaticUserAgentPlugin` that generates platform-specific User Agent strings
  - Supports all Apple platforms: iOS, macOS, watchOS, tvOS, and Mac Catalyst
  - Uses system APIs to detect device model, OS version, and app information
  - Generates User Agent strings following platform conventions
  - Initializes User Agent synchronously during plugin setup
  - User agent value: _Mozilla/5.0 (iPhone; CPU iPhone 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) SwiftUIExampleApp/1.0 Mobile/15E148_

- Both plugins follow the same event interception pattern:
  - Use `.preProcess` plugin type to modify events before transmission
  - Preserve existing event context while adding `userAgent` field
  - Return original event unchanged when User Agent is unavailable

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Build and run the SwiftUI example app**:
   ```bash
   cd Examples/SwiftUIExample
   open SwiftUIExample.xcodeproj
   # Build and run on different simulators/devices
   ```

2. **Verify WebKit behavior**:
   - Test DynamicUserAgentPlugin on platforms with WebKit support
   - Verify fallback behavior when WebKit is unavailable
   - Check async initialization completes properly

## Breaking Changes
**None** - This is purely additive functionality that doesn't modify existing SDK behavior. Both plugins are examples in the SwiftUIExample project and don't affect the core RudderStack SDK.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - These are code-only plugin implementations without UI changes.

## Additional Context
- **Plugin Architecture**: These implementations serve as comprehensive examples of how to create custom plugins for the RudderStack Swift SDK
- **Platform Support**: Full support for iOS, macOS, watchOS, tvOS, and Mac Catalyst environments
- **Performance**: DynamicUserAgentPlugin initializes asynchronously to avoid blocking, while StaticUserAgentPlugin is lightweight and synchronous
- **Use Cases**: 
  - Use DynamicUserAgentPlugin when you need authentic browser User Agent strings
  - Use StaticUserAgentPlugin for consistent, deterministic User Agent strings across app sessions
- **Error Handling**: Comprehensive error handling with proper logging via Swift SDK's logging system


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds user-agent enrichment to the SwiftUI example app with both dynamic (runtime-detected) and static (platform-aware) plugins.
  * Plugins inject or replace a userAgent value while preserving existing context fields and pass events through unchanged when UA is unavailable.

* **Tests**
  * Added unit tests covering UA injection, replacement, field preservation, pass-through behavior, and validation of generated UA strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->