### PR TITLE
refactor: separate reset entries builder for better Objective-C API design

### DIFF
--- a/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
+++ b/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
@@ -88,7 +88,7 @@
 }
 
 - (void)resetWithOptions {
-    RSSResetEntriedBuilder *entriesBuilder = [RSSResetEntriedBuilder new];
+    RSSResetEntriesBuilder *entriesBuilder = [RSSResetEntriesBuilder new];
     [entriesBuilder setResetAnonymousId: YES];
     [entriesBuilder setResetUserId: YES];
     [entriesBuilder setResetTraits: YES];

--- a/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
+++ b/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
@@ -88,13 +88,16 @@
 }
 
 - (void)resetWithOptions {
-    RSSResetOptionsBuilder *builder = [RSSResetOptionsBuilder new];
-    [builder setResetAnonymousId: YES];
-    [builder setResetUserId: YES];
-    [builder setResetTraits: YES];
-    [builder setResetSession: YES];
+    RSSResetEntriedBuilder *entriesBuilder = [RSSResetEntriedBuilder new];
+    [entriesBuilder setResetAnonymousId: YES];
+    [entriesBuilder setResetUserId: YES];
+    [entriesBuilder setResetTraits: YES];
+    [entriesBuilder setResetSession: YES];
     
-    [self.client resetWithOptions: [builder build]];
+    RSSResetOptionsBuilder *optionsBuilder = [RSSResetOptionsBuilder new];
+    [optionsBuilder setResetEntries:[entriesBuilder build]];
+    
+    [self.client resetWithOptions: [optionsBuilder build]];
 }
 
 - (void)startSession {

--- a/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
+++ b/Examples/ObjCExample/ObjCExample/AnalyticsManager/AnalyticsManager.m
@@ -89,13 +89,13 @@
 
 - (void)resetWithOptions {
     RSSResetEntriesBuilder *entriesBuilder = [RSSResetEntriesBuilder new];
-    [entriesBuilder setResetAnonymousId: YES];
-    [entriesBuilder setResetUserId: YES];
-    [entriesBuilder setResetTraits: YES];
-    [entriesBuilder setResetSession: YES];
+    [entriesBuilder setAnonymousIdResetEntry: YES];
+    [entriesBuilder setUserIdResetEntry: YES];
+    [entriesBuilder setTraitsResetEntry: YES];
+    [entriesBuilder setSessionResetEntry: YES];
     
     RSSResetOptionsBuilder *optionsBuilder = [RSSResetOptionsBuilder new];
-    [optionsBuilder setResetEntries:[entriesBuilder build]];
+    [optionsBuilder setEntries:[entriesBuilder build]];
     
     [self.client resetWithOptions: [optionsBuilder build]];
 }

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		532904F12E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 532904ED2E05BBDE00C8EFE2 /* SwiftUIExampleApp.xctestplan */; };
 		5358C58D2E702FCC0058E117 /* ResetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5358C58C2E702FCC0058E117 /* ResetEntries.swift */; };
 		5358C5912E7092FD0058E117 /* ObjCResetOptionsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5358C5902E7092FD0058E117 /* ObjCResetOptionsBuilder.swift */; };
+		5358C59B2E71A84F0058E117 /* ObjCResetEntriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5358C59A2E71A84F0058E117 /* ObjCResetEntriesBuilder.swift */; };
 		5393019E2E65562100DAEAD1 /* BackoffPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019D2E65562100DAEAD1 /* BackoffPolicyTests.swift */; };
 		539301D92E6F10A300DAEAD1 /* ResetOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301D82E6F10A300DAEAD1 /* ResetOptions.swift */; };
 		539D86F22E543997009FC144 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D86F12E543997009FC144 /* EventQueue.swift */; };
@@ -175,6 +176,7 @@
 		5351AA662C6BE95D003C3C47 /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5358C58C2E702FCC0058E117 /* ResetEntries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetEntries.swift; sourceTree = "<group>"; };
 		5358C5902E7092FD0058E117 /* ObjCResetOptionsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCResetOptionsBuilder.swift; sourceTree = "<group>"; };
+		5358C59A2E71A84F0058E117 /* ObjCResetEntriesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCResetEntriesBuilder.swift; sourceTree = "<group>"; };
 		5393019D2E65562100DAEAD1 /* BackoffPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackoffPolicyTests.swift; sourceTree = "<group>"; };
 		539301D82E6F10A300DAEAD1 /* ResetOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetOptions.swift; sourceTree = "<group>"; };
 		539D86F12E543997009FC144 /* EventQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueue.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				5328B87E2E3C8C6E0051A202 /* ObjCIdentifyEvent.swift */,
 				5328B8802E3C939D0051A202 /* ObjCAliasEvent.swift */,
 				5358C5902E7092FD0058E117 /* ObjCResetOptionsBuilder.swift */,
+				5358C59A2E71A84F0058E117 /* ObjCResetEntriesBuilder.swift */,
 			);
 			path = ObjC;
 			sourceTree = "<group>";
@@ -998,6 +1001,7 @@
 				53DEA6092E03D05A00D6C371 /* HttpClient.swift in Sources */,
 				53DEA60A2E03D05A00D6C371 /* ObjCConfiguration.swift in Sources */,
 				539D86F22E543997009FC144 /* EventQueue.swift in Sources */,
+				5358C59B2E71A84F0058E117 /* ObjCResetEntriesBuilder.swift in Sources */,
 				53DEA60B2E03D05A00D6C371 /* PluginChain.swift in Sources */,
 				539301D92E6F10A300DAEAD1 /* ResetOptions.swift in Sources */,
 				53DEA60C2E03D05A00D6C371 /* StorageModels.swift in Sources */,

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-@objc(RSSResetEntriedBuilder)
+/**
+ Builder pattern class for constructing ResetEntries instances in Objective-C environments.
+ 
+ Accommodates a fluent interface for configuring ResetEntries used in reset operations.
+ */
+@objc(RSSResetEntriesBuilder)
 public final class ObjCResetEntriesBuilder: NSObject {
     private var anonymousId: Bool = true
     private var userId: Bool = true
@@ -75,7 +80,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
     }
     
     /**
-     Builds and returns the configured `ObjCResetOptions` instance.
+     Builds and returns a ResetEntries instance configured with the specified options.
      */
     @objc
     public func build() -> ResetEntries {

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  Builder pattern class for constructing ResetEntries instances in Objective-C environments.
  
- Accommodates a fluent interface for configuring ResetEntries used in reset operations.
+ Provides a fluent interface for configuring ResetEntries used in reset operations.
  */
 @objc(RSSResetEntriesBuilder)
 public final class ObjCResetEntriesBuilder: NSObject {
@@ -80,7 +80,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
     }
     
     /**
-     Builds and returns a ResetEntries instance configured with the specified options.
+     Builds and returns a ResetEntries instance configured with the current builder settings.
      */
     @objc
     public func build() -> ResetEntries {

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
@@ -35,7 +35,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
      */
     @objc
     @discardableResult
-    public func setResetAnonymousId(_ reset: Bool) -> Self {
+    public func setAnonymousIdResetEntry(_ reset: Bool) -> Self {
         self.anonymousId = reset
         return self
     }
@@ -48,7 +48,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
      */
     @objc
     @discardableResult
-    public func setResetUserId(_ reset: Bool) -> Self {
+    public func setUserIdResetEntry(_ reset: Bool) -> Self {
         self.userId = reset
         return self
     }
@@ -61,7 +61,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
      */
     @objc
     @discardableResult
-    public func setResetTraits(_ reset: Bool) -> Self {
+    public func setTraitsResetEntry(_ reset: Bool) -> Self {
         self.traits = reset
         return self
     }
@@ -74,7 +74,7 @@ public final class ObjCResetEntriesBuilder: NSObject {
      */
     @objc
     @discardableResult
-    public func setResetSession(_ reset: Bool) -> Self {
+    public func setSessionResetEntry(_ reset: Bool) -> Self {
         self.session = reset
         return self
     }

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
@@ -6,3 +6,79 @@
 //
 
 import Foundation
+
+@objc(RSSResetEntriedBuilder)
+public final class ObjCResetEntriesBuilder: NSObject {
+    private var anonymousId: Bool = true
+    private var userId: Bool = true
+    private var traits: Bool = true
+    private var session: Bool = true
+    
+    /**
+     Initializes a new builder with default values.
+     */
+    @objc
+    public override init() {
+        super.init()
+    }
+    
+    /**
+     Sets whether to reset the anonymous ID.
+     
+     - Parameter reset: Whether to reset the anonymous ID. Defaults to `true`.
+     - Returns: The builder instance for chaining.
+     */
+    @objc
+    @discardableResult
+    public func setResetAnonymousId(_ reset: Bool) -> Self {
+        self.anonymousId = reset
+        return self
+    }
+    
+    /**
+     Sets whether to reset the user ID.
+     
+     - Parameter reset: Whether to reset the user ID. Defaults to `true`.
+     - Returns: The builder instance for chaining.
+     */
+    @objc
+    @discardableResult
+    public func setResetUserId(_ reset: Bool) -> Self {
+        self.userId = reset
+        return self
+    }
+    
+    /**
+     Sets whether to reset the traits.
+     
+     - Parameter reset: Whether to reset the traits. Defaults to `true`.
+     - Returns: The builder instance for chaining.
+     */
+    @objc
+    @discardableResult
+    public func setResetTraits(_ reset: Bool) -> Self {
+        self.traits = reset
+        return self
+    }
+    
+    /**
+     Sets whether to reset the session.
+     
+     - Parameter reset: Whether to reset the session. Defaults to `true`.
+     - Returns: The builder instance for chaining.
+     */
+    @objc
+    @discardableResult
+    public func setResetSession(_ reset: Bool) -> Self {
+        self.session = reset
+        return self
+    }
+    
+    /**
+     Builds and returns the configured `ObjCResetOptions` instance.
+     */
+    @objc
+    public func build() -> ResetEntries {
+        return ResetEntries(anonymousId: anonymousId, userId: userId, traits: traits, session: session)
+    }
+}

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetEntriesBuilder.swift
@@ -1,0 +1,8 @@
+//
+//  ObjCResetEntriesBuilder.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 10/09/25.
+//
+
+import Foundation

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  Builder pattern class for constructing ResetOptions instances in Objective-C environments.
  
- Accommodates a fluent interface for configuring ResetOptions.
+ Provides a fluent interface for configuring ResetOptions.
  */
 @objc(RSSResetOptionsBuilder)
 public final class ObjCResetOptionsBuilder: NSObject {

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
@@ -32,7 +32,7 @@ public final class ObjCResetOptionsBuilder: NSObject {
      */
     @objc
     @discardableResult
-    public func setResetEntries(_ entries: ResetEntries) -> Self {
+    public func setEntries(_ entries: ResetEntries) -> Self {
         self.resetEntries = entries
         return self
     }

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
@@ -13,78 +13,22 @@ import Foundation
  */
 @objc(RSSResetOptionsBuilder)
 public final class ObjCResetOptionsBuilder: NSObject {
+    private var resetEntries = ResetEntries()
     
-    private var anonymousId: Bool = true
-    private var userId: Bool = true
-    private var traits: Bool = true
-    private var session: Bool = true
-    
-    /**
-     Initializes a new builder with default values.
-     */
     @objc
     public override init() {
         super.init()
     }
     
-    /**
-     Sets whether to reset the anonymous ID.
-     
-     - Parameter reset: Whether to reset the anonymous ID. Defaults to `true`.
-     - Returns: The builder instance for chaining.
-     */
     @objc
     @discardableResult
-    public func setResetAnonymousId(_ reset: Bool) -> Self {
-        self.anonymousId = reset
+    public func setResetEntries(_ entries: ResetEntries) -> Self {
+        self.resetEntries = entries
         return self
     }
     
-    /**
-     Sets whether to reset the user ID.
-     
-     - Parameter reset: Whether to reset the user ID. Defaults to `true`.
-     - Returns: The builder instance for chaining.
-     */
-    @objc
-    @discardableResult
-    public func setResetUserId(_ reset: Bool) -> Self {
-        self.userId = reset
-        return self
-    }
-    
-    /**
-     Sets whether to reset the traits.
-     
-     - Parameter reset: Whether to reset the traits. Defaults to `true`.
-     - Returns: The builder instance for chaining.
-     */
-    @objc
-    @discardableResult
-    public func setResetTraits(_ reset: Bool) -> Self {
-        self.traits = reset
-        return self
-    }
-    
-    /**
-     Sets whether to reset the session.
-     
-     - Parameter reset: Whether to reset the session. Defaults to `true`.
-     - Returns: The builder instance for chaining.
-     */
-    @objc
-    @discardableResult
-    public func setResetSession(_ reset: Bool) -> Self {
-        self.session = reset
-        return self
-    }
-    
-    /**
-     Builds and returns the configured `ObjCResetOptions` instance.
-     */
     @objc
     public func build() -> ResetOptions {
-        let entries = ResetEntries(anonymousId: anonymousId, userId: userId, traits: traits, session: session)
-        return ResetOptions(entries: entries)
+        return ResetOptions(entries: resetEntries)
     }
 }

--- a/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
+++ b/Sources/RudderStackAnalytics/ObjC/ObjCResetOptionsBuilder.swift
@@ -6,20 +6,30 @@
 //
 
 import Foundation
+
 /**
  Builder pattern class for constructing ResetOptions instances in Objective-C environments.
  
- Provides a fluent interface for configuring selective user data reset preferences, allowing fine-grained control over which identity components should be cleared during reset operations.
+ Accommodates a fluent interface for configuring ResetOptions.
  */
 @objc(RSSResetOptionsBuilder)
 public final class ObjCResetOptionsBuilder: NSObject {
     private var resetEntries = ResetEntries()
     
+    /**
+     Initializes a new instance of the ObjCResetOptionsBuilder.
+     */
     @objc
     public override init() {
         super.init()
     }
     
+    /**
+     Sets the ResetEntries to be used in the ResetOptions.
+     
+     - Parameter entries: The ResetEntries instance specifying what to reset.
+     - Returns: The builder instance for chaining.
+     */
     @objc
     @discardableResult
     public func setResetEntries(_ entries: ResetEntries) -> Self {
@@ -27,6 +37,11 @@ public final class ObjCResetOptionsBuilder: NSObject {
         return self
     }
     
+    /**
+     Builds and returns a ResetOptions instance configured with the specified entries.
+     
+     - Returns: A ResetOptions instance.
+     */
     @objc
     public func build() -> ResetOptions {
         return ResetOptions(entries: resetEntries)


### PR DESCRIPTION
## Description
This PR refactors the Objective-C reset method implementation to improve API design and separation of concerns. The primary change introduces a new `ObjCResetEntriesBuilder` class to handle the construction of `ResetEntries` objects, while simplifying the `ObjCResetOptionsBuilder` to focus solely on `ResetOptions` configuration.

The refactoring addresses the overloaded responsibilities in the original `ObjCResetOptionsBuilder` by separating entry configuration from options configuration, resulting in a cleaner, more maintainable API structure that follows the builder pattern more precisely.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
- **New `ObjCResetEntriesBuilder` class**: Created a dedicated builder for constructing `ResetEntries` instances with fluent interface methods:
  - `setAnonymousIdResetEntry(_:)` - Controls anonymous ID reset behavior
  - `setUserIdResetEntry(_:)` - Controls user ID reset behavior
  - `setTraitsResetEntry(_:)` - Controls traits reset behavior
  - `setSessionResetEntry(_:)` - Controls session reset behavior
  - `build()` - Returns configured `ResetEntries` instance

- **Refactored `ObjCResetOptionsBuilder`**: Simplified to focus on `ResetOptions` configuration:
  - Removed individual property setters (`setResetAnonymousId`, `setResetUserId`, etc.)
  - Added `setEntries(_:)` method to accept a `ResetEntries` instance
  - `build()` method now creates `ResetOptions` with the provided `ResetEntries`

- **Updated Objective-C example**: Modified `AnalyticsManager.m` to demonstrate the new two-builder pattern:
  - First create and configure `RSSResetEntriesBuilder`
  - Then create `RSSResetOptionsBuilder` and set the built entries
  - Finally build and use the `ResetOptions`

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
The changes can be tested using the updated Objective-C example:

1. Open the `ObjCExample` project
2. Navigate to `AnalyticsManager.m`
3. Call the `resetWithOptions` method which demonstrates the new API usage
4. Verify that the reset functionality works as expected with the new builder pattern

The new API maintains the same functionality while providing better separation of concerns.

## Breaking Changes
This PR introduces breaking changes to the Objective-C API:

### Previous API (Deprecated):
```objective-c
RSSResetOptionsBuilder *builder = [RSSResetOptionsBuilder new];
[builder setResetAnonymousId: YES];
[builder setResetUserId: YES];
[builder setResetTraits: YES];
[builder setResetSession: YES];

[self.client resetWithOptions: [builder build]];
```

### New API:
```objective-c
// Create and configure reset entries
RSSResetEntriesBuilder *entriesBuilder = [RSSResetEntriesBuilder new];
[entriesBuilder setAnonymousIdResetEntry: YES];
[entriesBuilder setUserIdResetEntry: YES];
[entriesBuilder setTraitsResetEntry: YES];
[entriesBuilder setSessionResetEntry: YES];

// Create reset options with the entries
RSSResetOptionsBuilder *optionsBuilder = [RSSResetOptionsBuilder new];
[optionsBuilder setEntries:[entriesBuilder build]];

// Use the configured options
[self.client resetWithOptions: [optionsBuilder build]];
```

### Migration Guide:
Users upgrading to this version need to:

1. Replace direct property setters on `RSSResetOptionsBuilder` with the new two-builder pattern
2. Create a `RSSResetEntriesBuilder` instance first to configure what to reset
3. Pass the built entries to `RSSResetOptionsBuilder` using `setEntries:`
4. Build and use the `ResetOptions` as before

### Swift API (No Changes):
The Swift API remains unchanged and continues to work as expected:
```swift
let entries = ResetEntries(anonymousId: true, userId: true, traits: true, session: true)
let options = ResetOptions(entries: entries)
analytics.reset(options: options)
```

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
Not applicable - this is an internal API refactoring without UI changes.

## Additional Context
This refactoring aligns with the initiative to improve the Objective-C wrapper design. The separation of concerns between entry configuration and options configuration provides:

1. **Better API clarity**: Each builder has a single responsibility
2. **Improved maintainability**: Changes to entry configuration don't affect options configuration
3. **Enhanced extensibility**: Future additions to either entries or options can be made independently
4. **Consistent design patterns**: Follows established builder pattern conventions

The change maintains backward compatibility at the functional level (same reset behavior) while requiring code updates for the new API structure.
