### PR TITLE
feat: add generic plugin lookup to ensure proper configuration before initialization

### DIFF
--- a/Sources/RudderStackAnalytics/Base/Analytics.swift
+++ b/Sources/RudderStackAnalytics/Base/Analytics.swift
@@ -250,7 +250,8 @@ extension Analytics {
      - Parameter type: The type of plugin to find
      - Returns: The plugin instance if found, nil otherwise
      */
-    public func find<T: Plugin>(type: T.Type) -> T? {
+    public func find<T: Plugin>(_ type: T.Type) -> T? {
+        guard self.isAnalyticsActive else { return nil}
         return pluginChain?.find(type: type)
     }
     

--- a/Sources/RudderStackAnalytics/Base/Analytics.swift
+++ b/Sources/RudderStackAnalytics/Base/Analytics.swift
@@ -243,6 +243,17 @@ extension Analytics {
         guard self.isAnalyticsActive else { return }
         self.pluginChain?.remove(plugin: plugin)
     }
+    
+    /**
+     Finds a plugin of the specified type in the plugin chain.
+
+     - Parameter type: The type of plugin to find
+     - Returns: The plugin instance if found, nil otherwise
+     */
+    public func find<T: Plugin>(type: T.Type) -> T? {
+        return pluginChain?.find(type: type)
+    }
+    
 }
 
 // MARK: - Shutdown

--- a/Sources/RudderStackAnalytics/Plugins/Base/PluginChain.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Base/PluginChain.swift
@@ -21,7 +21,7 @@ class PluginChain {
         PluginType.allCases.forEach { self.pluginList[$0] = PluginInteractor() }
     }
     
-    func process(event: Event) {        
+    func process(event: Event) {
         let preProcessedResult = self.applyPlugins(pluginType: .preProcess, event: event)
         let onProcessedResult = self.applyPlugins(pluginType: .onProcess, event: preProcessedResult)
         
@@ -52,10 +52,11 @@ class PluginChain {
             mediator.removeAll()
         }
     }
-
+    
     func find<T: Plugin>(type: T.Type) -> T? {
-        for (_, mediator) in pluginList {
-            if let found = mediator.find(type) {
+        for pluginType in PluginType.allCases {
+            if let mediator = pluginList[pluginType],
+               let found = mediator.find(type) {
                 return found
             }
         }

--- a/Sources/RudderStackAnalytics/Plugins/Base/PluginChain.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Base/PluginChain.swift
@@ -52,6 +52,15 @@ class PluginChain {
             mediator.removeAll()
         }
     }
+
+    func find<T: Plugin>(type: T.Type) -> T? {
+        for (_, mediator) in pluginList {
+            if let found = mediator.find(type) {
+                return found
+            }
+        }
+        return nil
+    }
 }
 
 // MARK: - Private functions

--- a/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
+++ b/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
@@ -259,6 +259,22 @@ extension RudderStackAnalyticsTests {
             await client.configuration.storage.remove(batchReference: item.reference)
         }
     }
+
+    func test_findPlugin_disk() {
+        guard let client = analytics_disk else { return XCTFail("No disk client") }
+        
+        let customPlugin = MockPlugin()
+        client.add(plugin: customPlugin)
+        
+        let foundPlugin = client.find(type: MockPlugin.self)
+        XCTAssertNotNil(foundPlugin, "Should find the added plugin")
+        XCTAssertTrue(foundPlugin === customPlugin, "Should return the same plugin instance")
+        
+        client.remove(plugin: customPlugin)
+        
+        let removedPlugin = client.find(type: MockPlugin.self)
+        XCTAssertNil(removedPlugin, "Should not find plugin after removal")
+    }
 }
 
 // MARK: - Identify Reset Behavior Tests

--- a/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
+++ b/Tests/RudderStackAnalyticsTests/RudderStackAnalyticsTests.swift
@@ -266,13 +266,13 @@ extension RudderStackAnalyticsTests {
         let customPlugin = MockPlugin()
         client.add(plugin: customPlugin)
         
-        let foundPlugin = client.find(type: MockPlugin.self)
+        let foundPlugin = client.find(MockPlugin.self)
         XCTAssertNotNil(foundPlugin, "Should find the added plugin")
         XCTAssertTrue(foundPlugin === customPlugin, "Should return the same plugin instance")
         
         client.remove(plugin: customPlugin)
         
-        let removedPlugin = client.find(type: MockPlugin.self)
+        let removedPlugin = client.find(MockPlugin.self)
         XCTAssertNil(removedPlugin, "Should not find plugin after removal")
     }
 }


### PR DESCRIPTION
## Description
This PR introduces a generic find<T: Plugin> helper method that allows safe retrieval of plugins by type from the plugin chain. This enhancement was developed to solve configuration issues with PushNotificationPlugin where the plugin was already initialized during Analytics setup, causing subsequent calls to configurePushNotifications to fail to properly update the plugin's configuration.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
Added generic find<T: Plugin>(type: T.Type) -> T? method to Analytics class
Enables type-safe plugin retrieval from the plugin chain
Allows runtime plugin configuration updates after Analytics initialization
Solves plugin reconfiguration issues for push notifications and other plugins

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
Initialize Analytics with default configuration
Use the new find method to retrieve a specific plugin:
`   let analytics = Analytics(configuration: config)
   if let pushPlugin = analytics.find(type: PushNotificationPlugin.self) {
       // Update plugin configuration
       pushPlugin.updateConfiguration(newConfig)
   }`
Verify that plugin configuration updates work correctly after initialization
Test with different plugin types to ensure generic functionality

## Breaking Changes
None - this is a purely additive feature that maintains backward compatibility.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->
<img src="https://github.com/link" height="400" />

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public API to locate and retrieve a plugin instance by type from the analytics client; searches across the plugin chain and returns nil if not found or analytics is inactive.

- **Tests**
  - Added unit tests verifying plugin lookup returns the correct instance and nil after removal.
  - Added identify-reset behavior tests covering various userId/anonymousId scenarios for disk-backed analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->