### PR TITLE
feat: implement event batching based on anonymousId with automatic rollover

### DIFF
--- a/Sources/RudderStackAnalytics/EventQueue/EventWriter.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventWriter.swift
@@ -102,8 +102,8 @@ final class EventWriter {
     }
 
     private func updateAnonymousIdAndRolloverIfNeeded(processingEvent: ProcessingEvent) async {
-        guard let currentEventAnonymousId = processingEvent.event?.anonymousId,
-              currentEventAnonymousId != self.lastEventAnonymousId else { return }
+        guard let lastEventAnonymousId, let currentEventAnonymousId = processingEvent.event?.anonymousId,
+              currentEventAnonymousId != lastEventAnonymousId else { return }
         
         // Rollover when last and current anonymousId are different
         await self.storage.rollover()

--- a/Sources/RudderStackAnalytics/EventQueue/EventWriter.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventWriter.swift
@@ -17,7 +17,7 @@ final class EventWriter {
     private let writeChannel: AsyncChannel<ProcessingEvent>
     private let uploadChannel: AsyncChannel<String>
     private let flushEvent = ProcessingEvent(type: .flush)
-    
+    private var lastEventAnonymousId: String
     private var storage: Storage {
         return self.analytics.configuration.storage
     }
@@ -27,6 +27,8 @@ final class EventWriter {
         self.flushPolicyFacade = FlushPolicyFacade(analytics: analytics)
         self.writeChannel = writeChannel
         self.uploadChannel = uploadChannel
+        self.lastEventAnonymousId = analytics.configuration.storage.read(key: Constants.storageKeys.lastEventAnonymousId) ??
+                                   analytics.anonymousId ?? ""
     }
     
     func put(_ event: Event) {
@@ -60,6 +62,8 @@ final class EventWriter {
                 
                 // Process regular events (not flush signals)
                 if !isFlushSignal {
+                    await self.updateAnonymousIdAndRolloverIfNeeded(processingEvent: event)
+
                     if let json = event.event?.jsonString {
                         LoggerAnalytics.debug(log: "Processing event: \(json)")
                         await self.storage.write(event: json)
@@ -96,5 +100,16 @@ final class EventWriter {
     func stop() {
         guard !self.writeChannel.isClosed else { return }
         self.writeChannel.close()
+    }
+
+    private func updateAnonymousIdAndRolloverIfNeeded(processingEvent: ProcessingEvent) async {
+        let currentEventAnonymousId = processingEvent.event?.anonymousId ?? ""
+
+        if currentEventAnonymousId != self.lastEventAnonymousId {
+            // Rollover when last and current anonymousId are different
+            await self.storage.rollover()
+            self.lastEventAnonymousId = currentEventAnonymousId
+            self.storage.write(value: self.lastEventAnonymousId, key: Constants.storageKeys.lastEventAnonymousId)
+        }
     }
 }

--- a/Sources/RudderStackAnalytics/Helpers/Constants.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Constants.swift
@@ -70,6 +70,9 @@ struct _StorageKeys {
     /// Key for storing the anonymous user identifier.
     let anonymousId = "anonymous_id"
 
+    /// Key for storing the last event anonymous id, which is required for processing the batch of events.
+    let lastEventAnonymousId = "last_event_anonymous_id"
+
     /// Key for storing the identified user ID.
     let userId = "user_id"
 

--- a/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
+++ b/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
@@ -120,8 +120,6 @@ final class EventQueueTests: XCTestCase {
 
     func test_eventQueue_rolloverOnAnonymousIdChange() async {
         // Given - Events with different anonymous IDs
-        let expectation = expectation(description: "Storage should rollover when anonymousId changes")
-
         var event1 = TrackEvent(event: "event_1", properties: ["test": "value1"])
         event1.anonymousId = "anonymousId1"
 
@@ -148,9 +146,6 @@ final class EventQueueTests: XCTestCase {
         // We should have at least 2 batches (one for anonymousId1, one for anonymousId2)
         XCTAssertEqual(finalBatchCount - initialBatchCount, 2, "Storage should have rolled over when anonymousId changed")
 
-        expectation.fulfill()
-        await fulfillment(of: [expectation], timeout: 2.0)
-
         // Cleanup
         for item in finalDataItems {
             await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
@@ -159,8 +154,6 @@ final class EventQueueTests: XCTestCase {
 
     func test_eventQueue_sameAnonymousIdSingleBatch() async {
         // Given - Multiple events with the same anonymous ID
-        let expectation = expectation(description: "Events with same anonymousId should create only one batch")
-
         var event1 = TrackEvent(event: "event_1", properties: ["test": "value1"])
         event1.anonymousId = "consistentAnonymousId"
 
@@ -186,9 +179,6 @@ final class EventQueueTests: XCTestCase {
 
         // Should have exactly one new batch since all events have the same anonymousId
         XCTAssertEqual(finalBatchCount - initialBatchCount, 1, "Events with same anonymousId should create only one batch")
-
-        expectation.fulfill()
-        await fulfillment(of: [expectation], timeout: 2.0)
 
         // Cleanup
         for item in finalDataItems {

--- a/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
+++ b/Tests/RudderStackAnalyticsTests/EventQueue/EventQueueTests.swift
@@ -117,4 +117,82 @@ final class EventQueueTests: XCTestCase {
             await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
         }
     }
+
+    func test_eventQueue_rolloverOnAnonymousIdChange() async {
+        // Given - Events with different anonymous IDs
+        let expectation = expectation(description: "Storage should rollover when anonymousId changes")
+
+        var event1 = TrackEvent(event: "event_1", properties: ["test": "value1"])
+        event1.anonymousId = "anonymousId1"
+
+        var event2 = TrackEvent(event: "event_2", properties: ["test": "value2"])
+        event2.anonymousId = "anonymousId2"
+
+        // Track initial batch count
+        let initialDataItems = await mockAnalytics.configuration.storage.read().dataItems
+        let initialBatchCount = initialDataItems.count
+
+        // When - Send events with different anonymous IDs
+        eventQueue.put(event1)
+        eventQueue.put(event2)
+        try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+        
+        // Force rollover to finalize the batch
+        await mockAnalytics.configuration.storage.rollover()
+        try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+        
+        // Then - Check that rollovers occurred
+        let finalDataItems = await mockAnalytics.configuration.storage.read().dataItems
+        let finalBatchCount = finalDataItems.count
+
+        // We should have at least 2 batches (one for anonymousId1, one for anonymousId2)
+        XCTAssertEqual(finalBatchCount - initialBatchCount, 2, "Storage should have rolled over when anonymousId changed")
+
+        expectation.fulfill()
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        // Cleanup
+        for item in finalDataItems {
+            await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
+        }
+    }
+
+    func test_eventQueue_sameAnonymousIdSingleBatch() async {
+        // Given - Multiple events with the same anonymous ID
+        let expectation = expectation(description: "Events with same anonymousId should create only one batch")
+
+        var event1 = TrackEvent(event: "event_1", properties: ["test": "value1"])
+        event1.anonymousId = "consistentAnonymousId"
+
+        var event2 = TrackEvent(event: "event_2", properties: ["test": "value2"])
+        event2.anonymousId = "consistentAnonymousId"
+
+        // Track initial batch count
+        let initialDataItems = await mockAnalytics.configuration.storage.read().dataItems
+        let initialBatchCount = initialDataItems.count
+
+        // When - Send events with same anonymous ID
+        eventQueue.put(event1)
+        eventQueue.put(event2)
+        try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+
+        // Force rollover to finalize the batch
+        await mockAnalytics.configuration.storage.rollover()
+        try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+
+        // Then - Check that only one additional batch was created
+        let finalDataItems = await mockAnalytics.configuration.storage.read().dataItems
+        let finalBatchCount = finalDataItems.count
+
+        // Should have exactly one new batch since all events have the same anonymousId
+        XCTAssertEqual(finalBatchCount - initialBatchCount, 1, "Events with same anonymousId should create only one batch")
+
+        expectation.fulfill()
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        // Cleanup
+        for item in finalDataItems {
+            await mockAnalytics.configuration.storage.remove(batchReference: item.reference)
+        }
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

This PR implements intelligent event batching logic that automatically creates separate batches when the anonymousId changes between events. This ensures that events from different anonymous users are properly isolated in their own batches.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### Event Batching Logic
- **EventWriter Enhancement**: Added `lastEventAnonymousId` property to track the anonymousId of the most recent processed event
- **Automatic Rollover**: Implemented `updateAnonymousIdAndRolloverIfNeeded()` method that triggers storage rollover when anonymousId changes between consecutive events
- **Persistent State**: The last anonymousId is persisted to storage using the new `lastEventAnonymousId` storage key, ensuring continuity across app sessions

### Storage Integration
- **New Storage Key**: Added `Constants.storageKeys.lastEventAnonymousId` for persisting the last processed event's anonymousId
- **Rollover Trigger**: Storage rollover is automatically triggered when a new event has a different anonymousId than the previous event
- **Initialisation**: EventWriter now reads the last stored anonymousId during initialisation to maintain state across app restarts

### Event Processing Flow
1. When an event is processed, compare its anonymousId with the stored `lastEventAnonymousId`
2. If different, trigger storage rollover to finalise the current batch
3. Update the stored `lastEventAnonymousId` with the new value
4. Continue processing the event in the new batch

This approach ensures that events from different anonymous users are never mixed in the same batch, maintaining clean data separation for analytics processing.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. **Different AnonymousId Scenario**:
   - Send events with different anonymousId values / Or call RESET
   - Verify that storage creates separate batches for each unique anonymousId
   - Check that `lastEventAnonymousId` is updated in storage

2. **Same AnonymousId Scenario**:
   - Send multiple events with the same anonymousId
   - Verify that all events are grouped in a single batch
   - Ensure no unnecessary rollovers occur

3. **App Restart Scenario**:
   - Send events, restart the app, send more events
   - Verify that the last anonymousId state is preserved across sessions

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->
None

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event batching now automatically rolls over when the anonymous user ID changes, improving per-user isolation and analytics accuracy.
  * The last seen anonymous user ID is persisted so batching remains consistent across app launches and restarts, reducing cross-user data mixing.

* **Tests**
  * Added tests verifying rollover occurs when the anonymous ID changes and that batching is preserved when the ID stays the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->