### PR TITLE
fix: resolve the optional unwrapping value warning

### DIFF
--- a/Tests/RudderStackAnalyticsTests/Network/HttpClientTests.swift
+++ b/Tests/RudderStackAnalyticsTests/Network/HttpClientTests.swift
@@ -97,7 +97,7 @@ struct HttpClientTests {
     @Test("PrepareRequestUrl adds query parameters for configuration request")
     func prepareRequestUrl_addsQueryParametersForConfigurationRequest() {
         
-        guard let url = httpClient.prepareRequestUrl(for: .configuration) as? URL else {
+        guard let url = httpClient.prepareRequestUrl(for: .configuration) else {
             #expect(Bool(false), "SourceConfig request URL should not be null.")
             return
         }


### PR DESCRIPTION
## Description
This PR removes unnecessary type casting in the `HttpClientTests.swift` file. The `prepareRequestUrl(for:)` method already returns `URL?`, making the `as? URL` type cast redundant and causing compiler warnings.

The change is part of resolving Swift compiler warnings in the codebase.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Removed redundant `as? URL` type cast from the guard statement in `prepareRequestUrl_addsQueryParametersForConfigurationRequest()` test method
- The `HttpClient.prepareRequestUrl(for:)` method already returns `URL?`, so additional type casting is unnecessary
- This change resolves a compiler warning without affecting functionality

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Build the project and verify that the compiler warning is resolved
2. Run the existing test suite to ensure the test still passes correctly:
   ```bash
   swift test --filter HttpClientTests.prepareRequestUrl_addsQueryParametersForConfigurationRequest
   ```
3. Verify that the test method continues to validate the URL creation and query parameter functionality as intended

## Breaking Changes
None. This is a simple code cleanup that doesn't affect the public API or functionality.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
Not applicable - this is a code-only change.

## Additional Context
- The change maintains the same test logic and assertions while removing unnecessary type casting
- Similar patterns should be reviewed across the codebase to ensure consistency and warning-free compilation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up network client tests by removing redundant type casting and using clearer optional binding, improving readability and maintainability.
  * Preserved existing query parameter validations to ensure consistent coverage.
  * No impact on app behavior, performance, or build; this is a test-only refinement.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->