### PR TITLE
feat: add iOS app extension example with Swift SDK integration

### DIFF
--- a/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
+++ b/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
@@ -1,0 +1,348 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5322C3C92E97F93700DDDA72 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5322C3C72E97F93700DDDA72 /* ContentView.swift */; };
+		5322C3CA2E97F93700DDDA72 /* ExtensionExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5322C3C82E97F93700DDDA72 /* ExtensionExampleApp.swift */; };
+		5322C3CB2E97F93700DDDA72 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5322C3C62E97F93700DDDA72 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExtensionExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5322C3C62E97F93700DDDA72 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5322C3C72E97F93700DDDA72 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		5322C3C82E97F93700DDDA72 /* ExtensionExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionExampleApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5322C3B52E97F8E200DDDA72 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5322C3AF2E97F8E200DDDA72 = {
+			isa = PBXGroup;
+			children = (
+				5322C3CC2E97F96800DDDA72 /* ExtensionExample */,
+				5322C3B92E97F8E200DDDA72 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5322C3B92E97F8E200DDDA72 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5322C3CC2E97F96800DDDA72 /* ExtensionExample */ = {
+			isa = PBXGroup;
+			children = (
+				5322C3C62E97F93700DDDA72 /* Assets.xcassets */,
+				5322C3C72E97F93700DDDA72 /* ContentView.swift */,
+				5322C3C82E97F93700DDDA72 /* ExtensionExampleApp.swift */,
+			);
+			path = ExtensionExample;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5322C3B72E97F8E200DDDA72 /* ExtensionExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5322C3C32E97F8E300DDDA72 /* Build configuration list for PBXNativeTarget "ExtensionExample" */;
+			buildPhases = (
+				5322C3B42E97F8E200DDDA72 /* Sources */,
+				5322C3B52E97F8E200DDDA72 /* Frameworks */,
+				5322C3B62E97F8E200DDDA72 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExtensionExample;
+			packageProductDependencies = (
+			);
+			productName = ExtensionExample;
+			productReference = 5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5322C3B02E97F8E200DDDA72 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					5322C3B72E97F8E200DDDA72 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+				};
+			};
+			buildConfigurationList = 5322C3B32E97F8E200DDDA72 /* Build configuration list for PBXProject "ExtensionExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5322C3AF2E97F8E200DDDA72;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 5322C3B92E97F8E200DDDA72 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5322C3B72E97F8E200DDDA72 /* ExtensionExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5322C3B62E97F8E200DDDA72 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5322C3CB2E97F93700DDDA72 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5322C3B42E97F8E200DDDA72 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5322C3C92E97F93700DDDA72 /* ContentView.swift in Sources */,
+				5322C3CA2E97F93700DDDA72 /* ExtensionExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5322C3C12E97F8E300DDDA72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		5322C3C22E97F8E300DDDA72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5322C3C42E97F8E300DDDA72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ExtensionExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5322C3C52E97F8E300DDDA72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ExtensionExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5322C3B32E97F8E200DDDA72 /* Build configuration list for PBXProject "ExtensionExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5322C3C12E97F8E300DDDA72 /* Debug */,
+				5322C3C22E97F8E300DDDA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5322C3C32E97F8E300DDDA72 /* Build configuration list for PBXNativeTarget "ExtensionExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5322C3C42E97F8E300DDDA72 /* Debug */,
+				5322C3C52E97F8E300DDDA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5322C3B02E97F8E200DDDA72 /* Project object */;
+}

--- a/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
+++ b/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -435,6 +436,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -462,6 +464,7 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShareExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -490,6 +493,7 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShareExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
+++ b/Examples/ExtensionExample/ExtensionExample.xcodeproj/project.pbxproj
@@ -10,20 +10,89 @@
 		5322C3C92E97F93700DDDA72 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5322C3C72E97F93700DDDA72 /* ContentView.swift */; };
 		5322C3CA2E97F93700DDDA72 /* ExtensionExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5322C3C82E97F93700DDDA72 /* ExtensionExampleApp.swift */; };
 		5322C3CB2E97F93700DDDA72 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5322C3C62E97F93700DDDA72 /* Assets.xcassets */; };
+		53A83F152E9C05BD00DDA0CC /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 53A83F0B2E9C05BD00DDA0CC /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		53A83F1F2E9C06C300DDA0CC /* RudderStackAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A83F1E2E9C06C300DDA0CC /* RudderStackAnalytics.framework */; };
+		53A83F202E9C06C300DDA0CC /* RudderStackAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53A83F1E2E9C06C300DDA0CC /* RudderStackAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		53A83F132E9C05BD00DDA0CC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5322C3B02E97F8E200DDDA72 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 53A83F0A2E9C05BD00DDA0CC;
+			remoteInfo = ShareExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		53A83F162E9C05BD00DDA0CC /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				53A83F152E9C05BD00DDA0CC /* ShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53A83F212E9C06C300DDA0CC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				53A83F202E9C06C300DDA0CC /* RudderStackAnalytics.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExtensionExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5322C3C62E97F93700DDDA72 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5322C3C72E97F93700DDDA72 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5322C3C82E97F93700DDDA72 /* ExtensionExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionExampleApp.swift; sourceTree = "<group>"; };
+		53A83F0B2E9C05BD00DDA0CC /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		53A83F1E2E9C06C300DDA0CC /* RudderStackAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderStackAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		53A83F192E9C05BD00DDA0CC /* Exceptions for "ShareExtension" folder in "ShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 53A83F0A2E9C05BD00DDA0CC /* ShareExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		53A83F0C2E9C05BD00DDA0CC /* ShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				53A83F192E9C05BD00DDA0CC /* Exceptions for "ShareExtension" folder in "ShareExtension" target */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		5322C3B52E97F8E200DDDA72 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53A83F082E9C05BD00DDA0CC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53A83F1F2E9C06C300DDA0CC /* RudderStackAnalytics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -34,6 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				5322C3CC2E97F96800DDDA72 /* ExtensionExample */,
+				53A83F0C2E9C05BD00DDA0CC /* ShareExtension */,
+				53A83F1D2E9C06C300DDA0CC /* Frameworks */,
 				5322C3B92E97F8E200DDDA72 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -42,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */,
+				53A83F0B2E9C05BD00DDA0CC /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -56,6 +128,14 @@
 			path = ExtensionExample;
 			sourceTree = "<group>";
 		};
+		53A83F1D2E9C06C300DDA0CC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				53A83F1E2E9C06C300DDA0CC /* RudderStackAnalytics.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -66,10 +146,12 @@
 				5322C3B42E97F8E200DDDA72 /* Sources */,
 				5322C3B52E97F8E200DDDA72 /* Frameworks */,
 				5322C3B62E97F8E200DDDA72 /* Resources */,
+				53A83F162E9C05BD00DDA0CC /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				53A83F142E9C05BD00DDA0CC /* PBXTargetDependency */,
 			);
 			name = ExtensionExample;
 			packageProductDependencies = (
@@ -77,6 +159,29 @@
 			productName = ExtensionExample;
 			productReference = 5322C3B82E97F8E200DDDA72 /* ExtensionExample.app */;
 			productType = "com.apple.product-type.application";
+		};
+		53A83F0A2E9C05BD00DDA0CC /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 53A83F1A2E9C05BD00DDA0CC /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				53A83F072E9C05BD00DDA0CC /* Sources */,
+				53A83F082E9C05BD00DDA0CC /* Frameworks */,
+				53A83F092E9C05BD00DDA0CC /* Resources */,
+				53A83F212E9C06C300DDA0CC /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				53A83F0C2E9C05BD00DDA0CC /* ShareExtension */,
+			);
+			name = ShareExtension;
+			packageProductDependencies = (
+			);
+			productName = ShareExtension;
+			productReference = 53A83F0B2E9C05BD00DDA0CC /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -89,6 +194,9 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					5322C3B72E97F8E200DDDA72 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+					53A83F0A2E9C05BD00DDA0CC = {
 						CreatedOnToolsVersion = 26.0;
 					};
 				};
@@ -108,6 +216,7 @@
 			projectRoot = "";
 			targets = (
 				5322C3B72E97F8E200DDDA72 /* ExtensionExample */,
+				53A83F0A2E9C05BD00DDA0CC /* ShareExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -118,6 +227,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				5322C3CB2E97F93700DDDA72 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53A83F092E9C05BD00DDA0CC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,7 +249,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		53A83F072E9C05BD00DDA0CC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		53A83F142E9C05BD00DDA0CC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 53A83F0A2E9C05BD00DDA0CC /* ShareExtension */;
+			targetProxy = 53A83F132E9C05BD00DDA0CC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		5322C3C12E97F8E300DDDA72 /* Debug */ = {
@@ -277,7 +408,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ExtensionExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -309,11 +440,67 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ExtensionExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		53A83F172E9C05BD00DDA0CC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		53A83F182E9C05BD00DDA0CC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudder.extension.example.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
@@ -338,6 +525,15 @@
 			buildConfigurations = (
 				5322C3C42E97F8E300DDDA72 /* Debug */,
 				5322C3C52E97F8E300DDDA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		53A83F1A2E9C05BD00DDA0CC /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				53A83F172E9C05BD00DDA0CC /* Debug */,
+				53A83F182E9C05BD00DDA0CC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/Contents.json
+++ b/Examples/ExtensionExample/ExtensionExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/ExtensionExample/ExtensionExample/ContentView.swift
+++ b/Examples/ExtensionExample/ExtensionExample/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  ExtensionExample
+//
+//  Created by Satheesh Kannan on 09/10/25.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Examples/ExtensionExample/ExtensionExample/ExtensionExampleApp.swift
+++ b/Examples/ExtensionExample/ExtensionExample/ExtensionExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  ExtensionExampleApp.swift
+//  ExtensionExample
+//
+//  Created by Satheesh Kannan on 09/10/25.
+//
+
+import SwiftUI
+
+@main
+struct ExtensionExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Examples/ExtensionExample/ShareExtension/Info.plist
+++ b/Examples/ExtensionExample/ShareExtension/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>NSExtension</key>
+        <dict>
+            <key>NSExtensionAttributes</key>
+            <dict>
+                <key>NSExtensionActivationRule</key>
+                <dict>
+                    <key>NSExtensionActivationSupportsText</key>
+                    <true/>
+                </dict>
+            </dict>
+            <key>NSExtensionPointIdentifier</key>
+            <string>com.apple.share-services</string>
+            <key>NSExtensionPrincipalClass</key>
+            <string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+        </dict>
+    </dict>
+</plist>

--- a/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
@@ -1,0 +1,47 @@
+//
+//  ShareExtensionView.swift
+//  ShareExtension
+//
+//  Created by Satheesh Kannan on 07/10/25.
+//
+
+import SwiftUI
+
+struct ShareExtensionView: View {
+    @State var text: String
+    var onSend: (String) -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Make an Event")
+                .font(.title3)
+                .bold()
+            
+            TextEditor(text: $text)
+                .font(.body)
+                .padding(8)
+                .frame(height: 120) // 👈 Limit height
+                .background(Color(UIColor.secondarySystemBackground))
+                .cornerRadius(10)
+            
+            Button(action: {
+                onSend(text)
+            }) {
+                Text("Send")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+        }
+        .padding()
+        .background(Color(UIColor.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+}
+
+#Preview {
+    ShareExtensionView(text: "Hit it.!!") {_ in }
+}

--- a/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
@@ -7,13 +7,14 @@
 
 import SwiftUI
 
+// MARK: - ShareExtensionView
 struct ShareExtensionView: View {
     @State var text: String
-    var onSend: (String) -> Void
+    var onButtonTapped: (String?, ShareButtonActionType) -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Make an Event")
+            Text("Analytics Actions")
                 .font(.title3)
                 .bold()
             
@@ -24,16 +25,23 @@ struct ShareExtensionView: View {
                 .background(Color(UIColor.secondarySystemBackground))
                 .cornerRadius(10)
             
-            Button(action: {
-                onSend(text)
-            }) {
-                Text("Send")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
+            HStack {
+                ShareExtensionButton(action: {
+                    onButtonTapped(text, .track)
+                }, tite: "Track")
+                
+                ShareExtensionButton(action: {
+                    onButtonTapped(nil, .flush)
+                }, tite: "Flush")
             }
+            
+            ShareExtensionButton(action: {
+                onButtonTapped(nil, .shutdown)
+            }, tite: "Shutdown")
+            
+            ShareExtensionButton(action: {
+                onButtonTapped(nil, .cancel)
+            }, tite: "Cancel", isCancel: true)
         }
         .padding()
         .background(Color(UIColor.systemBackground))
@@ -42,6 +50,35 @@ struct ShareExtensionView: View {
     }
 }
 
+// MARK: - ShareExtensionButton
+struct ShareExtensionButton: View {
+    var action: @MainActor () -> Void
+    var tite: String
+    var isCancel: Bool = false
+    
+    var body: some View {
+        Button(action: action) {
+            Text(tite)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(isCancel ? .gray.opacity(0.2) : .blue)
+                .foregroundColor(isCancel ? .black.opacity(0.5) : .white)
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isCancel ? Color.gray.opacity(0.4) : .clear, lineWidth: 1))
+        }
+    }
+}
+
+// MARK: - ShareButtonActionType
+enum ShareButtonActionType {
+    case track
+    case flush
+    case shutdown
+    case cancel
+}
+
 #Preview {
-    ShareExtensionView(text: "Hit it.!!") {_ in }
+    ShareExtensionView(text: "Hit it.!!") {_,_  in }
 }

--- a/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
@@ -45,7 +45,7 @@ struct ShareExtensionView: View {
             
             Spacer()
             
-            Text("This is not a proper share extension; it’s a demo app built only to showcase how RudderStackAnalytics works inside an extension.")
+            Text("This is not a proper share extension; it’s a demo app built only to showcase how RudderStackAnalytics SDK works inside an extension.")
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(.gray.opacity(0.2))

--- a/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareExtensionView.swift
@@ -28,24 +28,37 @@ struct ShareExtensionView: View {
             HStack {
                 ShareExtensionButton(action: {
                     onButtonTapped(text, .track)
-                }, tite: "Track")
+                }, title: "Track")
                 
                 ShareExtensionButton(action: {
                     onButtonTapped(nil, .flush)
-                }, tite: "Flush")
+                }, title: "Flush")
             }
             
             ShareExtensionButton(action: {
                 onButtonTapped(nil, .shutdown)
-            }, tite: "Shutdown")
+            }, title: "Shutdown")
             
             ShareExtensionButton(action: {
                 onButtonTapped(nil, .cancel)
-            }, tite: "Cancel", isCancel: true)
+            }, title: "Cancel", isCancel: true)
+            
+            Spacer()
+            
+            Text("This is not a proper share extension; it’s a demo app built only to showcase how RudderStackAnalytics works inside an extension.")
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(.gray.opacity(0.2))
+                .foregroundColor(.black.opacity(0.5))
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.gray.opacity(0.4), lineWidth: 1))
+            Spacer()
         }
         .padding()
         .background(Color(UIColor.systemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .frame(maxHeight: .infinity, alignment: .top)
     }
 }
@@ -53,12 +66,12 @@ struct ShareExtensionView: View {
 // MARK: - ShareExtensionButton
 struct ShareExtensionButton: View {
     var action: @MainActor () -> Void
-    var tite: String
+    var title: String
     var isCancel: Bool = false
     
     var body: some View {
         Button(action: action) {
-            Text(tite)
+            Text(title)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(isCancel ? .gray.opacity(0.2) : .blue)

--- a/Examples/ExtensionExample/ShareExtension/ShareViewController.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareViewController.swift
@@ -10,6 +10,7 @@ import Social
 import SwiftUI
 import RudderStackAnalytics
 
+// MARK: - ShareViewController
 class ShareViewController: UIViewController {
     
     var analytics: Analytics?
@@ -96,6 +97,8 @@ class ShareViewController: UIViewController {
         }
     }
 }
+
+// MARK: - RudderStackAnalytics
 
 extension ShareViewController {
     func initializeAnalyticsSDK() {

--- a/Examples/ExtensionExample/ShareExtension/ShareViewController.swift
+++ b/Examples/ExtensionExample/ShareExtension/ShareViewController.swift
@@ -1,0 +1,109 @@
+//
+//  ShareViewController.swift
+//  ShareExtension
+//
+//  Created by Satheesh Kannan on 07/10/25.
+//
+
+import UIKit
+import Social
+import SwiftUI
+import RudderStackAnalytics
+
+class ShareViewController: UIViewController {
+    
+    var analytics: Analytics?
+    
+    override func loadView() {
+        super.loadView()
+        self.initializeAnalyticsSDK()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if let screen = view.window?.windowScene?.screen {
+            preferredContentSize = CGSize(width: screen.bounds.width, height: 260)
+        }
+        // Extract shared text
+        handleIncomingText()
+    }
+    
+    private func handleIncomingText() {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let attachments = item.attachments else { return }
+        
+        for provider in attachments where provider.hasItemConformingToTypeIdentifier("public.text") {
+            provider.loadItem(forTypeIdentifier: "public.text", options: nil) { [weak self] (item, error) in
+                guard let self = self else { return }
+                
+                if let error = error {
+                    print("Failed to load text: \(error.localizedDescription)")
+                    return
+                }
+                
+                var sharedText: String?
+                
+                if let text = item as? String {
+                    sharedText = text
+                } else if let url = item as? URL {
+                    sharedText = url.absoluteString
+                }
+                
+                guard let text = sharedText else { return }
+                
+                DispatchQueue.main.async {
+                    self.showSwiftUIView(with: text)
+                }
+            }
+        }
+    }
+    
+    private func showSwiftUIView(with text: String) {
+        let contentView = UIHostingController(rootView: ShareExtensionView(text: text) {
+            self.handleSend(text: $0)
+        })
+        
+        addChild(contentView)
+        view.addSubview(contentView.view)
+        contentView.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            contentView.view.topAnchor.constraint(equalTo: view.topAnchor),
+            contentView.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            contentView.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentView.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        contentView.didMove(toParent: self)
+    }
+    
+    private func handleSend(text: String) {
+        // ✅ Handle your send action here
+        // e.g., save to shared UserDefaults, write to a shared file, or trigger an API
+        
+        self.analytics?.track(name: text)
+        
+        // Complete the share
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.analytics?.flush()
+            // Wait briefly before ending the extension
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.analytics?.shutdown()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.analytics = nil
+                    self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)}
+            }
+        }
+    }
+}
+
+extension ShareViewController {
+    func initializeAnalyticsSDK() {
+        // Set the log level for analytics
+        LoggerAnalytics.logLevel = .verbose
+
+        // Initialize the RudderStack Analytics SDK
+        let config = Configuration(writeKey: "<WRITE_KEY>", dataPlaneUrl: "<DATA_PLANE_URL>")
+        self.analytics = Analytics(configuration: config)
+    }
+}

--- a/RudderStackAnalytics.xcworkspace/contents.xcworkspacedata
+++ b/RudderStackAnalytics.xcworkspace/contents.xcworkspacedata
@@ -22,4 +22,7 @@
    <FileRef
       location = "group:Examples/tvOSExample/tvOSExample.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Examples/ExtensionExample/ExtensionExample.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## Description
This PR adds a complete iOS app extension example to demonstrate how to integrate RudderStack Analytics SDK within iOS app extensions, specifically share extensions. The example includes a main iOS app with a share extension that allows users to share text content while tracking events using the RudderStack Analytics SDK.

The implementation addresses the need for developers to understand how to properly integrate and use RudderStack Analytics in app extensions, which have different lifecycle constraints compared to regular iOS apps.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **New Xcode project**: Created `Examples/ExtensionExample/ExtensionExample.xcodeproj` with proper targets for both main app and share extension
- **Main iOS app**: Implemented basic SwiftUI app structure with `ExtensionExampleApp.swift` and `ContentView.swift`
- **Share extension implementation**:
  - `ShareViewController.swift`: Main extension controller handling incoming shared content and RudderStack Analytics integration
  - `ShareExtensionView.swift`: Custom SwiftUI view providing user interface for the share extension
  - `Info.plist`: Proper extension configuration supporting text sharing
- **Analytics integration**: Demonstrates proper SDK initialization, event tracking, and cleanup in extension context
- **Project structure**: Added extension example to main workspace for easy access and building
- **Asset management**: Included standard iOS app assets (AppIcon, AccentColor)

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Run on iOS Simulator**:
   - Open the ExtensionExample project in Xcode
   - Build and run the ExtensionExample target on iOS Simulator
   - Install the app which includes the share extension

2. **Test share extension**:
   - Open Safari or any app that supports text sharing
   - Share some text content
   - Select "ExtensionExample" from the share sheet
   - Verify the custom share UI appears
   - Send the shared content and verify analytics events are tracked

3. **Verify analytics integration**:
   - Configure `WRITE_KEY` and `DATA_PLANE_URL` in `ShareViewController.swift`
   - Monitor network requests or RudderStack dashboard to confirm events are being sent
   - Check console logs for verbose analytics output

## Breaking Changes
None. This is a new example project that doesn't affect existing SDK functionality.

## Screenshots (if applicable)
<img width="302" height="656" alt="Simulator Screenshot - iPhone 17 Pro - 2025" src="https://github.com/user-attachments/assets/3c171131-47ff-4d20-962a-073cd203b46e" />

The share extension provides a custom SwiftUI interface that allows users to:
- View and edit shared text content
- Send the content as an analytics event
- Seamlessly integrate with iOS share workflows

## Additional Context
This example provides a comprehensive sample setup for iOS app extensions. Key considerations implemented:

- **Extension lifecycle management**: Proper SDK initialization and shutdown within extension constraints
- **Asynchronous operations**: Handling analytics flush and shutdown with appropriate delays
- **Memory management**: Proper cleanup of analytics instance to prevent memory leaks
- **User experience**: Custom SwiftUI interface that follows iOS design guidelines
- **Configuration**: Clear placeholders for required analytics configuration (write key, data plane URL)

The example serves as both a testing ground for extension functionality and documentation for developers implementing similar integrations.

**Related files modified:**
- `RudderStackAnalytics.xcworkspace/contents.xcworkspacedata` - Added new project to workspace
- Multiple new files under `Examples/ExtensionExample/` - Complete new example project structure

**Dependencies:**
- RudderStackAnalytics framework (embedded in share extension)
- SwiftUI for modern iOS UI implementation
- Standard iOS extension frameworks (Social, UIKit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ExtensionExample iOS app built with SwiftUI, featuring a simple home view and previews.
  * Added a Share Extension that accepts text from other apps and shows a compose UI with action buttons (track, flush, shutdown, cancel).
  * Added app icons and an accent color asset.

* **Chores**
  * Configured project and workspace to include the app and Share Extension with build and signing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->