### PR TITLE
chore: update migration classes implementation for V1 SDK

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
@@ -253,6 +253,7 @@ enum PersistenceKeysV1 {
     static let legacyApplicationBuild = "rl_application_build_key"
     
     // Keys that may exist within traits dictionary
+    static let traitsIdKey = "id"
     static let traitsUserIdKey = "userId"
     static let traitsAnonymousIdKey = "anonymousId"
     

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
@@ -118,6 +118,14 @@ enum MigrationUtilsV1 {
             dict[PersistenceKeysV1.legacyLastEventTimeStamp] = lastEventTime
         }
         
+        if let appVersion = userDefaults.object(forKey: PersistenceKeysV1.legacyApplicationVersion) {
+            dict[PersistenceKeysV1.legacyApplicationVersion] = appVersion
+        }
+        
+        if let appBuild = userDefaults.object(forKey: PersistenceKeysV1.legacyApplicationBuild) {
+            dict[PersistenceKeysV1.legacyApplicationBuild] = appBuild
+        }
+        
         return dict.isEmpty ? nil : dict
     }
     
@@ -264,7 +272,6 @@ enum PersistenceKeysV1 {
     
     static let sessionId = "session_id"
     static let isManualSession = "is_manual_session"
-    static let isSessionStart = "is_session_start"
     static let lastActivityTime = "last_activity_time"
     
     static let applicationVersion = "rudder.app_version"

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
@@ -159,7 +159,9 @@ enum MigrationUtilsV1 {
          PersistenceKeysV1.legacyTraitsKey,
          PersistenceKeysV1.legacySessionId,
          PersistenceKeysV1.legacyIsSessionAutoTrackEnabled,
-         PersistenceKeysV1.legacyLastEventTimeStamp
+         PersistenceKeysV1.legacyLastEventTimeStamp,
+         PersistenceKeysV1.legacyApplicationVersion,
+         PersistenceKeysV1.legacyApplicationBuild
         ].forEach { UserDefaults.standard.removeObject(forKey: $0) }
         UserDefaults.standard.synchronize()
         

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
@@ -291,7 +291,7 @@ private extension PersistentMigratorFromV1 {
         log("Migrated user ID")
     }
 
-    /// Writes traits to Swift SDK storage (excluding userId and anonymousId which are stored separately)
+    /// Writes traits to Swift SDK storage (excluding userId, id and anonymousId)
     func writeTraits(_ traits: [String: Any]?, to defaults: UserDefaults) {
         guard var traits = traits else { return }
 
@@ -300,6 +300,11 @@ private extension PersistentMigratorFromV1 {
         traits.removeValue(forKey: PersistenceKeysV1.traitsUserIdKey)
         traits.removeValue(forKey: PersistenceKeysV1.traitsIdKey)
 
+        guard !traits.isEmpty else {
+            log("Traits empty after removing IDs - skipping traits migration")
+            return
+        }
+        
         guard let encodedTraits = MigrationUtilsV1.encodeJSONDict(traits) else {
             log("Failed to encode traits - traits will not be migrated")
             return

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
@@ -298,6 +298,7 @@ private extension PersistentMigratorFromV1 {
         // Remove IDs from traits - they are stored separately in Swift SDK
         traits.removeValue(forKey: PersistenceKeysV1.traitsAnonymousIdKey)
         traits.removeValue(forKey: PersistenceKeysV1.traitsUserIdKey)
+        traits.removeValue(forKey: PersistenceKeysV1.traitsIdKey)
 
         guard let encodedTraits = MigrationUtilsV1.encodeJSONDict(traits) else {
             log("Failed to encode traits - traits will not be migrated")

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
@@ -315,7 +315,6 @@ private extension PersistentMigratorFromV1 {
         writeSessionId(sessionData.sessionId, to: defaults)
         writeIsManualSession(sessionData.isManualSession, to: defaults)
         writeLastActivityTime(sessionData.lastActivityTime, to: defaults)
-        writeSessionStartFlag(to: defaults)
     }
 
     /// Writes session ID to Swift SDK storage
@@ -338,12 +337,6 @@ private extension PersistentMigratorFromV1 {
 
         defaults.set(String(lastActivityTime), forKey: PersistenceKeysV1.lastActivityTime)
         log("Migrated lastActivityTime: \(lastActivityTime)")
-    }
-
-    /// Marks session as not starting (since we're restoring an existing session)
-    func writeSessionStartFlag(to defaults: UserDefaults) {
-        defaults.set(false, forKey: PersistenceKeysV1.isSessionStart)
-        log("Set isSessionStart to false")
     }
 
     /// Writes application data to Swift SDK storage


### PR DESCRIPTION
## Description
This PR improves the persistence migration from V1 SDK by addressing two key issues:

1. **Enhanced Legacy Data Cleanup**: Added cleanup for legacy application version and build keys (`legacyApplicationVersion` and `legacyApplicationBuild`) that were being migrated but not properly cleared from UserDefaults during the migration process.

2. **Removed Redundant Session Start Flag**: Eliminated the unnecessary `writeSessionStartFlag` function and its call during session data migration. This function was setting `isSessionStart` to false during migration, which is redundant since session restoration shouldn't trigger new session start flags.

These changes ensure cleaner migration by properly cleaning up all legacy keys and removing unnecessary session initialization logic during the restoration process.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Migration Cleanup Enhancement**: Added `PersistenceKeysV1.legacyApplicationVersion` and `PersistenceKeysV1.legacyApplicationBuild` to the list of legacy keys that are removed from UserDefaults after successful migration
- **Session Migration Simplification**: Removed `writeSessionStartFlag()` method and its call from `writeSessionData()` as it was setting an unnecessary flag during session restoration
- **Code Cleanup**: Eliminated dead code related to session start flag management during migration

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
To test these changes:

1. **Legacy Data Cleanup Testing**:
   - Set up a device/simulator with V1 SDK data including application version and build information
   - Perform migration using the updated migrator
   - Verify that `rl_application_version_key` and `rl_application_build_key` are properly removed from UserDefaults after migration
   - Confirm that the application data is still properly migrated to the new storage format

2. **Session Migration Testing**:
   - Set up a device/simulator with V1 SDK session data
   - Perform migration and verify that session data is properly restored
   - Confirm that no unnecessary `isSessionStart` flag is set during migration
   - Verify that session functionality works correctly after migration

3. **Integration Testing**:
   - Test full migration flow with all types of legacy data
   - Verify that the migration completes successfully and all legacy keys are cleaned up
   - Confirm that the migrated SDK functions normally without any residual legacy data

## Breaking Changes
None. These are internal migration improvements that don't affect the public API or change existing behavior for end users.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
Not applicable - this is an internal migration improvement without UI changes.

## Additional Context
This change addresses an issue where legacy application version and build keys were not being properly cleaned up after migration, potentially leaving residual data in UserDefaults. The removal of the redundant session start flag simplifies the migration logic and prevents unnecessary session state manipulation during restoration.

The changes are backward compatible and only affect the migration process itself, not the runtime behavior of the SDK after migration is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy data cleanup to remove deprecated application version/build entries and the legacy traits "id" during migration.

* **Refactor**
  * Simplified session migration by removing the step that reset the session-start flag, avoiding unnecessary flag updates.

* **Changes**
  * Migration now preserves legacy application version and build values when transferring data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->