### PR TITLE
feat: add persistence migration utility for legacy V2 SDK compatibility

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		535BB3FB2E04643900E1DAB0 /* BluetoothInfoPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F12E04643900E1DAB0 /* BluetoothInfoPluginTests.swift */; };
 		535BB3FC2E04643900E1DAB0 /* SwiftUIAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */; };
 		535BB3FD2E04643900E1DAB0 /* AppTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BB3F02E04643900E1DAB0 /* AppTestingHelper.swift */; };
+		53825E112F03C06200B20FCF /* MigrationUtilsV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53825E0F2F03C06200B20FCF /* MigrationUtilsV2.swift */; };
+		53825E122F03C06200B20FCF /* PersistentMigratorFromV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53825E102F03C06200B20FCF /* PersistentMigratorFromV2.swift */; };
+		53825E132F03C06200B20FCF /* LegacyDataModelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53825E0E2F03C06200B20FCF /* LegacyDataModelV2.swift */; };
 		539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */; };
 		539301C82E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */; };
 		539301CA2E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539301C92E6AFAEC00DAEAD1 /* StaticUserAgentPlugin.swift */; };
@@ -91,6 +94,9 @@
 		535BB3F32E04643900E1DAB0 /* SetAnonymousIdPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAnonymousIdPluginTests.swift; sourceTree = "<group>"; };
 		535BB3F42E04643900E1DAB0 /* SetPushTokenPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPushTokenPluginTests.swift; sourceTree = "<group>"; };
 		535BB3F52E04643900E1DAB0 /* SwiftUIAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIAppTests.swift; sourceTree = "<group>"; };
+		53825E0E2F03C06200B20FCF /* LegacyDataModelV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDataModelV2.swift; sourceTree = "<group>"; };
+		53825E0F2F03C06200B20FCF /* MigrationUtilsV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationUtilsV2.swift; sourceTree = "<group>"; };
+		53825E102F03C06200B20FCF /* PersistentMigratorFromV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMigratorFromV2.swift; sourceTree = "<group>"; };
 		5383D2CE2D3EAC0C00291B00 /* SwiftUIExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUIExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5393019F2E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPlugin.swift; sourceTree = "<group>"; };
 		539301C72E6AF27900DAEAD1 /* DynamicUserAgentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserAgentPluginTests.swift; sourceTree = "<group>"; };
@@ -220,10 +226,21 @@
 			path = SwiftUIExampleTests;
 			sourceTree = "<group>";
 		};
+		53825E142F03C06700B20FCF /* FromV2 */ = {
+			isa = PBXGroup;
+			children = (
+				53825E0F2F03C06200B20FCF /* MigrationUtilsV2.swift */,
+				53825E0E2F03C06200B20FCF /* LegacyDataModelV2.swift */,
+				53825E102F03C06200B20FCF /* PersistentMigratorFromV2.swift */,
+			);
+			path = FromV2;
+			sourceTree = "<group>";
+		};
 		53E687562EF9233000DF1FBD /* PersistenceMigrator */ = {
 			isa = PBXGroup;
 			children = (
 				53E6876C2EFB179300DF1FBD /* FromV1 */,
+				53825E142F03C06700B20FCF /* FromV2 */,
 			);
 			path = PersistenceMigrator;
 			sourceTree = "<group>";
@@ -350,6 +367,9 @@
 				535BB3E92E04642400E1DAB0 /* SetAnonymousIdPlugin.swift in Sources */,
 				539301A02E69A5B000DAEAD1 /* DynamicUserAgentPlugin.swift in Sources */,
 				53E687542EF9232200DF1FBD /* PersistentMigratorFromV1.swift in Sources */,
+				53825E112F03C06200B20FCF /* MigrationUtilsV2.swift in Sources */,
+				53825E122F03C06200B20FCF /* PersistentMigratorFromV2.swift in Sources */,
+				53825E132F03C06200B20FCF /* LegacyDataModelV2.swift in Sources */,
 				53E687552EF9232200DF1FBD /* MigrationUtilsV1.swift in Sources */,
 				535BB3EA2E04642400E1DAB0 /* ContentView.swift in Sources */,
 				535BB3EB2E04642400E1DAB0 /* BluetoothInfoPlugin.swift in Sources */,

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/LegacyDataModelV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/LegacyDataModelV2.swift
@@ -1,0 +1,64 @@
+//
+//  LegacyDataModelV2.swift
+//  MultiRSA
+//
+//  Created by Satheesh Kannan on 24/12/25.
+//
+
+import Foundation
+
+/// Holds all extracted legacy data from V2 SDK in a structured format
+struct LegacyDataV2 {
+    let anonymousId: String?
+    let userId: String?
+    let traits: [String: Any]?
+    let sessionData: SessionDataV2?
+    let applicationData: ApplicationDataV2?
+
+    /// Converts legacy data to a dictionary for public API
+    func toDictionary() -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        if let anonymousId {
+            result["anonymousId"] = anonymousId
+        }
+        if let userId {
+            result["userId"] = userId
+        }
+        if let traits {
+            result["traits"] = traits
+        }
+        if let sessionData {
+            result["sessionId"] = sessionData.sessionId
+            if let lastActivityTime = sessionData.lastActivityTime {
+                result["lastActivityTime"] = lastActivityTime
+            }
+            if let isManualSession = sessionData.isManualSession {
+                result["isManualSession"] = isManualSession
+            }
+        }
+        if let applicationData {
+            if let version = applicationData.version {
+                result["applicationVersion"] = version
+            }
+            if let build = applicationData.build {
+                result["applicationBuild"] = build
+            }
+        }
+
+        return result
+    }
+}
+
+/// Holds session-related data extracted from legacy V2 storage
+struct SessionDataV2 {
+    let sessionId: UInt64
+    let lastActivityTime: UInt64?
+    let isManualSession: Bool?
+}
+
+/// Holds application version data extracted from legacy V2 storage
+struct ApplicationDataV2 {
+    let version: String?
+    let build: String?
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/MigrationUtilsV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/MigrationUtilsV2.swift
@@ -1,0 +1,307 @@
+//
+//  MigrationUtilsV2.swift
+//  MultiRSA
+//
+//  Created by Satheesh Kannan on 24/12/25.
+//
+
+import Foundation
+
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(watchOS)
+import WatchKit
+#elseif os(macOS)
+import Cocoa
+#endif
+
+/**
+ Utility methods for V2 persistence operations including JSON encoding/decoding
+ and timestamp conversions. V2 uses only UserDefaults.standard as legacy storage.
+ */
+enum MigrationUtilsV2 {
+    
+    // MARK: - UserDefaults
+    
+    /**
+     Creates a UserDefaults instance for the new Swift SDK
+     - Parameter writeKey: The write key for the analytics instance
+     - Returns: UserDefaults instance with the appropriate suite name, or nil if bundle identifier unavailable
+     */
+    static func rudderSwiftDefaults(_ writeKey: String) -> UserDefaults? {
+        guard let suiteName = swiftSuiteName(for: writeKey) else { return nil }
+        return UserDefaults(suiteName: suiteName)
+    }
+    
+    /**
+     Checks if the Swift SDK UserDefaults suite exists
+     - Parameter writeKey: The write key for the analytics instance
+     - Returns: True if the UserDefaults suite exists, false otherwise
+     */
+    static func isSwiftDefaultsAvailable(_ writeKey: String) -> Bool {
+        guard let suiteName = swiftSuiteName(for: writeKey) else { return false }
+        return UserDefaults.standard.persistentDomain(forName: suiteName) != nil
+    }
+    
+    /// Generates the UserDefaults suite name for the Swift SDK
+    private static func swiftSuiteName(for writeKey: String) -> String? {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return nil }
+        return "\(bundleIdentifier).analytics.\(writeKey)"
+    }
+    
+    // MARK: - JSON Encoding/Decoding
+    
+    /**
+     Encodes a dictionary as a JSON string
+     - Parameter dictionary: Dictionary to encode
+     - Returns: JSON string representation, or nil if encoding fails
+     */
+    static func encodeJSONDict(_ dictionary: [String: Any]?) -> String? {
+        guard let dictionary = dictionary,
+              JSONSerialization.isValidJSONObject(dictionary),
+              let data = try? JSONSerialization.data(withJSONObject: dictionary),
+              let jsonString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return jsonString
+    }
+    
+    /**
+     Decodes a JSON dictionary from a string
+     - Parameter jsonString: JSON string to decode
+     - Returns: Decoded dictionary, or nil if decoding fails
+     */
+    static func decodeJSONDict(from jsonString: String?) -> [String: Any]? {
+        guard let jsonString = jsonString,
+              let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+    
+    // MARK: - Legacy UserDefaults Operations
+    
+    /**
+     Reads UserDefaults.standard values and returns them as a dictionary
+     - Returns: Dictionary of legacy V2 values from UserDefaults, or nil if none found
+     */
+    static func readLegacyUserDefaults() -> [String: Any]? {
+        let userDefaults = UserDefaults.standard
+        var dict: [String: Any] = [:]
+        
+        // Allowed classes for unarchiving traits
+        let allowedJSONClasses: [AnyClass] = [
+            NSDictionary.self,
+            NSArray.self,
+            NSString.self,
+            NSNumber.self,
+            NSNull.self
+        ]
+        
+        // Read all potential legacy V2 keys
+        if let userId = userDefaults.string(forKey: PersistenceKeysV2.legacyUserIdKey) {
+            dict[PersistenceKeysV2.legacyUserIdKey] = userId
+        }
+        
+        if let traitsData = userDefaults.data(forKey: PersistenceKeysV2.legacyTraitsKey), let traits = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: allowedJSONClasses, from: traitsData) as? [String: Any] {
+            dict[PersistenceKeysV2.legacyTraitsKey] = traits
+        }
+        
+        if let sessionId = userDefaults.object(forKey: PersistenceKeysV2.legacySessionId) {
+            dict[PersistenceKeysV2.legacySessionId] = sessionId
+        }
+        
+        if let isManualTrack = userDefaults.object(forKey: PersistenceKeysV2.legacyIsSessionAutoTrackEnabled) {
+            dict[PersistenceKeysV2.legacyIsSessionAutoTrackEnabled] = isManualTrack
+        }
+        
+        if let lastEventTime = userDefaults.object(forKey: PersistenceKeysV2.legacyLastEventTimeStamp) {
+            dict[PersistenceKeysV2.legacyLastEventTimeStamp] = lastEventTime
+        }
+        
+        if let appVersion = userDefaults.object(forKey: PersistenceKeysV2.legacyApplicationVersion) {
+            dict[PersistenceKeysV2.legacyApplicationVersion] = appVersion
+        }
+        
+        if let appBuild = userDefaults.object(forKey: PersistenceKeysV2.legacyApplicationBuild) {
+            dict[PersistenceKeysV2.legacyApplicationBuild] = appBuild
+        }
+        
+        // Anonymous ID not stored explicitly, it is derived from device `identifierForVendor`
+        // If other data exists, add anonymousId to the dictionary
+        if !dict.isEmpty, let anonymousId = MigrationUtilsV2.getAnonymousId() {
+            dict[PersistenceKeysV2.anonymousIdKey] = anonymousId
+        }
+        
+        return dict.isEmpty ? nil : dict
+    }
+    
+    /**
+     Clears all legacy V2 persistence data from UserDefaults.standard
+     
+     This should be called after successful migration to clean up legacy data.
+     */
+    static func clearLegacyData() {
+        // Remove legacy keys from UserDefaults.standard
+        [PersistenceKeysV2.legacyUserIdKey,
+         PersistenceKeysV2.legacyTraitsKey,
+         PersistenceKeysV2.legacySessionId,
+         PersistenceKeysV2.legacyIsSessionAutoTrackEnabled,
+         PersistenceKeysV2.legacyLastEventTimeStamp,
+         PersistenceKeysV2.legacyApplicationVersion,
+         PersistenceKeysV2.legacyApplicationBuild
+        ].forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        UserDefaults.standard.synchronize()
+        
+        print("MigrationUtilsV2: Cleared legacy UserDefaults values")
+    }
+    
+    // MARK: - Timestamp Conversion
+    
+    /**
+     Converts a legacy wall-clock timestamp (timeIntervalSince1970) into a
+     system uptime value (ProcessInfo.processInfo.systemUptime) expressed
+     in milliseconds.
+     
+     This method is used during SDK migration where the legacy SDK stored
+     the last activity time as an absolute timestamp, while the new SDK
+     stores it as system uptime (time since last device boot).
+     
+     Conversion logic:
+     - Read the current timestamp (t_now)
+     - Read the current system uptime (u_now)
+     - Calculate the system boot timestamp:
+     bootTimestamp = t_now - u_now
+     - Calculate the uptime at which the legacy event occurred:
+     uptimeAtTimestamp = legacyTimestamp - bootTimestamp
+     
+     If the legacy timestamp occurred before the current system boot,
+     the conversion is not possible and the method returns nil.
+     
+     Important notes:
+     - This conversion only succeeds if the device has not rebooted since
+     the legacy timestamp was recorded.
+     - If a reboot occurred, returning nil is the correct and safe behavior.
+     
+     - Parameter timestamp:
+     Legacy timestamp represented as timeIntervalSince1970.
+     
+     - Returns:
+     System uptime in milliseconds corresponding to the legacy timestamp,
+     or nil if the conversion is not valid.
+     */
+    static func convertTimestampToSystemUptime(_ timestamp: Double) -> UInt64? {
+        let currentTimestamp = Date().timeIntervalSince1970
+        let currentUptime = ProcessInfo.processInfo.systemUptime
+        
+        // Timestamp must be valid and in the past
+        guard timestamp > 0, timestamp <= currentTimestamp else {
+            print("MigrationUtilsV2: Invalid timestamp: \(timestamp)")
+            return nil
+        }
+        
+        // Calculate system boot time as a timestamp
+        let bootTimestamp = currentTimestamp - currentUptime
+        
+        // Calculate uptime at the time of the legacy timestamp
+        let uptimeAtTimestamp = timestamp - bootTimestamp
+        guard uptimeAtTimestamp >= 0 else {
+            print("MigrationUtilsV2: Timestamp predates system boot: \(timestamp)")
+            return nil
+        }
+        
+        // Convert seconds to milliseconds
+        return UInt64(uptimeAtTimestamp * 1000)
+    }
+    
+    // MARK: - Anonymous ID Retrieval
+    /**
+     Retrieves the device's anonymous ID used in legacy V2 storage.
+     - Returns: The anonymous ID string, or nil if unavailable
+     */
+    private static func getAnonymousId() -> String? {
+#if os(iOS) || os(tvOS)
+        return UIDevice.current.identifierForVendor?.uuidString.lowercased()
+#endif
+#if os(watchOS)
+        return WKInterfaceDevice.current().identifierForVendor?.uuidString.lowercased()
+#endif
+#if os(macOS)
+        return macAddress(bsd: "en0")
+#endif
+    }
+    
+    /**
+     Retrieves the MAC address for a given BSD interface name on macOS.
+     - Parameter bsd: The BSD interface name (e.g., "en0")
+     - Returns: The MAC address string, or nil if unavailable
+     */
+    private static func macAddress(bsd: String) -> String? {
+        let MAC_ADDRESS_LENGTH = 6
+        let separator = ":"
+        
+        var length: size_t = 0
+        var buffer: [CChar]
+        
+        let bsdIndex = Int32(if_nametoindex(bsd))
+        if bsdIndex == 0 {
+            return nil
+        }
+        let bsdData = Data(bsd.utf8)
+        var managementInfoBase = [CTL_NET, AF_ROUTE, 0, AF_LINK, NET_RT_IFLIST, bsdIndex]
+        
+        if sysctl(&managementInfoBase, 6, nil, &length, nil, 0) < 0 {
+            return nil
+        }
+        
+        buffer = [CChar](unsafeUninitializedCapacity: length, initializingWith: {buffer, initializedCount in
+            for x in 0..<length { buffer[x] = 0 }
+            initializedCount = length
+        })
+        
+        if sysctl(&managementInfoBase, 6, &buffer, &length, nil, 0) < 0 {
+            return nil
+        }
+        
+        let infoData = Data(bytes: buffer, count: length)
+        let indexAfterMsghdr = MemoryLayout<if_msghdr>.stride + 1
+        let rangeOfToken = infoData[indexAfterMsghdr...].range(of: bsdData)!
+        let lower = rangeOfToken.upperBound
+        let upper = lower + MAC_ADDRESS_LENGTH
+        let macAddressData = infoData[lower..<upper]
+        let addressBytes = macAddressData.map { String(format: "%02x", $0) }
+        return addressBytes.joined(separator: separator)
+    }
+}
+
+// MARK: - Persistence Keys
+enum PersistenceKeysV2 {
+    // Keys read from legacy storage (UserDefaults.standard)
+    static let legacyUserIdKey = "rs_user_id"
+    static let legacyTraitsKey = "rs_traits"
+    
+    static let legacySessionId = "rl_session_id"
+    static let legacyLastEventTimeStamp = "rl_last_event_time_stamp"
+    static let legacyIsSessionAutoTrackEnabled = "rl_session_manual_track_status"
+    
+    static let legacyApplicationVersion = "rs_application_version_key"
+    static let legacyApplicationBuild = "rs_application_build_key"
+    
+    // Keys that may exist within traits dictionary
+    static let traitsIdKey = "id"
+    static let traitsUserIdKey = "userId"
+    static let traitsAnonymousIdKey = "anonymousId"
+    
+    // Keys used for storing values in the new Swift SDK
+    static let anonymousIdKey = "anonymous_id"
+    static let userIdKey = "user_id"
+    static let traitsKey = "traits"
+    
+    static let sessionId = "session_id"
+    static let isManualSession = "is_manual_session"
+    static let lastActivityTime = "last_activity_time"
+    
+    static let applicationVersion = "rudder.app_version"
+    static let applicationBuild = "rudder.app_build"
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
@@ -22,7 +22,7 @@ import Foundation
 
  Note:
  - V2 SDK stores data only in UserDefaults.standard.
- - V2 SDK don't stores the anonymousId anywhere it uses current device's `identifierForVendor` instead.
+ - V2 SDK doesn't store the anonymousId anywhere; it uses the current device's `identifierForVendor` instead.
 
  ## Usage
 
@@ -210,7 +210,7 @@ private extension PersistentMigratorFromV2 {
         return SessionDataV2(
             sessionId: sessionIdNumber.uint64Value,
             lastActivityTime: lastActivityTime,
-            isManualSession: isManualSession,
+            isManualSession: isManualSession
         )
     }
 
@@ -231,7 +231,7 @@ private extension PersistentMigratorFromV2 {
     /// Extracts manual session flag
     /// Note: V2 stores this directly as manual status (no inversion needed unlike V1)
     func extractIsManualSession(from dict: [String: Any]) -> Bool? {
-        guard let isManualTrack = dict[PersistenceKeysV2.legacyIsSessionAutoTrackEnabled] as? NSNumber else {
+        guard let isManualTrack = dict[PersistenceKeysV2.legacySessionManualTrackStatus] as? NSNumber else {
             return nil
         }
         return isManualTrack.boolValue

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
@@ -1,0 +1,382 @@
+//
+//  PersistentMigratorFromV2.swift
+//  MultiRSA
+//
+//  Created by Satheesh Kannan on 24/12/25.
+//
+
+import Foundation
+
+// MARK: - PersistentMigratorFromV2
+
+/**
+ Migrates persistence data from the Rudder iOS SDK V2 to the new Swift SDK.
+
+ This class reads data stored by the V2 SDK from UserDefaults.standard and writes it
+ to the Swift SDK's UserDefaults suite. It handles migration of:
+ - Anonymous Id
+ - User ID
+ - User traits
+ - Session data
+ - Application version and build
+
+ Note:
+ - V2 SDK stores data only in UserDefaults.standard.
+ - V2 SDK don't stores the anonymousId anywhere it uses current device's `identifierForVendor` instead.
+
+ ## Usage
+
+ Call `restorePersistence()` once during app initialization, **before** initializing the RudderStack Swift SDK:
+
+ ```swift
+ // In AppDelegate or App init
+ let migrator = PersistentMigratorFromV2(writeKey: "your_write_key")
+ migrator.restorePersistence()
+
+ // Then initialize the Swift SDK
+ let config = Configuration(writeKey: "sample-write-key", dataPlaneUrl: "https://data-plane.analytics.com")
+ let analytics = Analytics(configuration: config)
+ ```
+
+ ## Inspecting Legacy Data
+
+ Use `readPersistence()` to inspect what data will be migrated:
+
+ ```swift
+ let migrator = PersistentMigratorFromV2(writeKey: "your_write_key")
+ if let legacyData = migrator.readPersistence() {
+     print("Data to migrate: \(legacyData)")
+ }
+ ```
+ */
+public final class PersistentMigratorFromV2 {
+
+    // MARK: - Properties
+
+    /// The write key used to identify the Swift SDK's UserDefaults suite
+    private let writeKey: String
+
+    // MARK: - Initialization
+
+    /**
+     Creates a new persistence migrator.
+
+     - Parameter writeKey: The write key for your RudderStack Swift SDK instance
+     */
+    public init(writeKey: String) {
+        self.writeKey = writeKey
+    }
+
+    // MARK: - Public API
+
+    /**
+     Reads legacy V2 SDK persistence data without performing migration.
+
+     Use this method to inspect what data will be migrated before calling `restorePersistence()`.
+
+     - Returns: Dictionary containing legacy data, or `nil` if no legacy data exists.
+
+     The dictionary contains the following keys (if available):
+     - `anonymousId`: The anonymous ID (String)
+     - `userId`: The user ID (String)
+     - `traits`: User traits dictionary ([String: Any])
+     - `sessionId`: Session ID (UInt64)
+     - `lastActivityTime`: Last activity time in milliseconds (UInt64)
+     - `isManualSession`: Whether session tracking is manual (Bool)
+     - `applicationVersion`: The application version (String)
+     - `applicationBuild`: The application build number (String)
+     */
+    public func readPersistence() -> [String: Any]? {
+        guard let legacyData = extractLegacyData() else {
+            return nil
+        }
+        return legacyData.toDictionary()
+    }
+
+    /**
+     Restores legacy V2 SDK persistence data to the Swift SDK.
+
+     This method:
+     1. Checks if Swift SDK storage already exists (aborts if so)
+     2. Reads legacy data from UserDefaults.standard
+     3. Transforms and writes data to the Swift SDK's storage
+     4. Clears legacy data after successful migration
+
+     Safe to call multiple times - returns early if Swift SDK data or no legacy data exists.
+     */
+    public func restorePersistence() {
+        guard !MigrationUtilsV2.isSwiftDefaultsAvailable(writeKey) else {
+            log("Swift SDK storage already exists, skipping migration")
+            return
+        }
+
+        guard let legacyData = extractLegacyData() else {
+            log("No legacy data found, skipping migration")
+            return
+        }
+
+        guard let targetDefaults = MigrationUtilsV2.rudderSwiftDefaults(writeKey) else {
+            log("Failed to access Swift SDK storage for writeKey: \(writeKey)")
+            return
+        }
+
+        log("Starting migration for writeKey: \(writeKey)")
+
+        writeMigratedData(legacyData, to: targetDefaults)
+        completeMigration(targetDefaults)
+    }
+}
+
+// MARK: - Reading Legacy Data
+
+private extension PersistentMigratorFromV2 {
+
+    /// Extracts legacy data from UserDefaults.standard
+    func extractLegacyData() -> LegacyDataV2? {
+        guard let dict = MigrationUtilsV2.readLegacyUserDefaults() else {
+            return nil
+        }
+
+        log("Found legacy data in UserDefaults")
+        return extractLegacyData(from: dict)
+    }
+}
+
+// MARK: - Extracting Legacy Values
+
+private extension PersistentMigratorFromV2 {
+
+    /// Extracts all legacy values from a source dictionary into a structured format
+    func extractLegacyData(from dict: [String: Any]) -> LegacyDataV2? {
+        let anonymousId = extractAnonymousId(from: dict)
+        let (userId, traits) = extractUserIdAndTraits(from: dict)
+        let sessionData = extractSessionData(from: dict)
+        let applicationData = extractApplicationData(from: dict)
+
+        // Return nil if no data was extracted
+        if anonymousId == nil && userId == nil && traits == nil && sessionData == nil && applicationData == nil {
+            return nil
+        }
+
+        return LegacyDataV2(
+            anonymousId: anonymousId,
+            userId: userId,
+            traits: traits,
+            sessionData: sessionData,
+            applicationData: applicationData
+        )
+    }
+    
+    /// Extracts anonymous ID
+    func extractAnonymousId(from dict: [String: Any]) -> String? {
+        // Get anonymousId from the dedicated key
+        guard let anonymousId = dict[PersistenceKeysV2.anonymousIdKey] as? String else {
+            log("Anonymous ID not found in legacy storage")
+            return nil
+        }
+        
+        return anonymousId
+    }
+
+    /// Extracts user ID and traits from legacy storage
+    /// In V2, userId is stored separately but also may exist in traits
+    func extractUserIdAndTraits(from dict: [String: Any]) -> (userId: String?, traits: [String: Any]?) {
+        // First try to get userId from the dedicated key
+        var userId = dict[PersistenceKeysV2.legacyUserIdKey] as? String
+
+        // Get traits if available
+        guard let traits = dict[PersistenceKeysV2.legacyTraitsKey] as? [String: Any] else {
+            return (userId, nil)
+        }
+
+        // If userId wasn't found in dedicated key, try to get it from traits
+        if userId == nil {
+            userId = traits[PersistenceKeysV2.traitsUserIdKey] as? String
+        }
+
+        return (userId, traits)
+    }
+
+    /// Extracts session-related data from legacy storage
+    func extractSessionData(from dict: [String: Any]) -> SessionDataV2? {
+        guard let sessionIdNumber = dict[PersistenceKeysV2.legacySessionId] as? NSNumber else {
+            log("No active session details found.")
+            return nil
+        }
+
+        let lastActivityTime = extractLastActivityTime(from: dict)
+        let isManualSession = extractIsManualSession(from: dict)
+
+        return SessionDataV2(
+            sessionId: sessionIdNumber.uint64Value,
+            lastActivityTime: lastActivityTime,
+            isManualSession: isManualSession,
+        )
+    }
+
+    /// Extracts and converts last activity time from legacy timestamp format
+    func extractLastActivityTime(from dict: [String: Any]) -> UInt64? {
+        guard let timestampNumber = dict[PersistenceKeysV2.legacyLastEventTimeStamp] as? NSNumber else {
+            return nil
+        }
+
+        guard let convertedTime = MigrationUtilsV2.convertTimestampToSystemUptime(timestampNumber.doubleValue) else {
+            log("Failed to convert lastEventTimeStamp - session timing may be affected")
+            return nil
+        }
+
+        return convertedTime
+    }
+
+    /// Extracts manual session flag
+    /// Note: V2 stores this directly as manual status (no inversion needed unlike V1)
+    func extractIsManualSession(from dict: [String: Any]) -> Bool? {
+        guard let isManualTrack = dict[PersistenceKeysV2.legacyIsSessionAutoTrackEnabled] as? NSNumber else {
+            return nil
+        }
+        return isManualTrack.boolValue
+    }
+
+    /// Extracts application version and build from legacy storage
+    func extractApplicationData(from dict: [String: Any]) -> ApplicationDataV2? {
+        let version = dict[PersistenceKeysV2.legacyApplicationVersion] as? String
+        let build = dict[PersistenceKeysV2.legacyApplicationBuild] as? String
+
+        // Return nil if neither value exists
+        guard version != nil || build != nil else {
+            return nil
+        }
+
+        return ApplicationDataV2(version: version, build: build)
+    }
+}
+
+// MARK: - Writing Migrated Data
+
+private extension PersistentMigratorFromV2 {
+
+    /// Writes all migrated data to Swift SDK storage
+    func writeMigratedData(_ data: LegacyDataV2, to defaults: UserDefaults) {
+        writeAnonymousId(data.anonymousId, to: defaults)
+        writeUserId(data.userId, to: defaults)
+        writeTraits(data.traits, to: defaults)
+        writeSessionData(data.sessionData, to: defaults)
+        writeApplicationData(data.applicationData, to: defaults)
+    }
+
+    /// Writes anonymous ID to Swift SDK storage
+    func writeAnonymousId(_ anonymousId: String?, to defaults: UserDefaults) {
+        guard let anonymousId = anonymousId else { return }
+
+        defaults.set(anonymousId, forKey: PersistenceKeysV2.anonymousIdKey)
+        log("Migrated anonymous Id")
+    }
+    
+    /// Writes user ID to Swift SDK storage
+    func writeUserId(_ userId: String?, to defaults: UserDefaults) {
+        guard let userId = userId else { return }
+
+        defaults.set(userId, forKey: PersistenceKeysV2.userIdKey)
+        log("Migrated user ID")
+    }
+
+    /// Writes traits to Swift SDK storage (excluding userId, id and anonymousId)
+    func writeTraits(_ traits: [String: Any]?, to defaults: UserDefaults) {
+        guard var traits = traits else { return }
+
+        // Remove IDs from traits - they are stored separately in Swift SDK
+        traits.removeValue(forKey: PersistenceKeysV2.traitsAnonymousIdKey)
+        traits.removeValue(forKey: PersistenceKeysV2.traitsUserIdKey)
+        traits.removeValue(forKey: PersistenceKeysV2.traitsIdKey)
+
+        guard !traits.isEmpty else {
+            log("Traits empty after removing IDs - skipping traits migration")
+            return
+        }
+
+        guard let encodedTraits = MigrationUtilsV2.encodeJSONDict(traits) else {
+            log("Failed to encode traits - traits will not be migrated")
+            return
+        }
+
+        defaults.set(encodedTraits, forKey: PersistenceKeysV2.traitsKey)
+        log("Migrated user traits")
+    }
+
+    /// Writes session data to Swift SDK storage
+    func writeSessionData(_ sessionData: SessionDataV2?, to defaults: UserDefaults) {
+        guard let sessionData = sessionData else { return }
+
+        writeSessionId(sessionData.sessionId, to: defaults)
+        writeIsManualSession(sessionData.isManualSession, to: defaults)
+        writeLastActivityTime(sessionData.lastActivityTime, to: defaults)
+    }
+
+    /// Writes session ID to Swift SDK storage
+    func writeSessionId(_ sessionId: UInt64, to defaults: UserDefaults) {
+        defaults.set(String(sessionId), forKey: PersistenceKeysV2.sessionId)
+        log("Migrated session ID: \(sessionId)")
+    }
+
+    /// Writes manual session flag to Swift SDK storage
+    func writeIsManualSession(_ isManualSession: Bool?, to defaults: UserDefaults) {
+        guard let isManualSession = isManualSession else { return }
+
+        defaults.set(isManualSession, forKey: PersistenceKeysV2.isManualSession)
+        log("Migrated isManualSession: \(isManualSession)")
+    }
+
+    /// Writes last activity time to Swift SDK storage
+    func writeLastActivityTime(_ lastActivityTime: UInt64?, to defaults: UserDefaults) {
+        guard let lastActivityTime = lastActivityTime else { return }
+
+        defaults.set(String(lastActivityTime), forKey: PersistenceKeysV2.lastActivityTime)
+        log("Migrated lastActivityTime: \(lastActivityTime)")
+    }
+
+    /// Writes application data to Swift SDK storage
+    func writeApplicationData(_ applicationData: ApplicationDataV2?, to defaults: UserDefaults) {
+        guard let applicationData = applicationData else { return }
+
+        writeApplicationVersion(applicationData.version, to: defaults)
+        writeApplicationBuild(applicationData.build, to: defaults)
+    }
+
+    /// Writes application version to Swift SDK storage
+    func writeApplicationVersion(_ version: String?, to defaults: UserDefaults) {
+        guard let version = version else { return }
+
+        defaults.set(version, forKey: PersistenceKeysV2.applicationVersion)
+        log("Migrated application version: \(version)")
+    }
+
+    /// Writes application build to Swift SDK storage (converts String to Int)
+    func writeApplicationBuild(_ build: String?, to defaults: UserDefaults) {
+        guard let build = build, let buildNumber = Int(build) else { return }
+
+        defaults.set(buildNumber, forKey: PersistenceKeysV2.applicationBuild)
+        log("Migrated application build: \(buildNumber)")
+    }
+}
+
+// MARK: - Migration Completion
+
+private extension PersistentMigratorFromV2 {
+
+    /// Completes migration by persisting changes and clearing legacy data
+    func completeMigration(_ defaults: UserDefaults) {
+        defaults.synchronize()
+        MigrationUtilsV2.clearLegacyData()
+        log("Migration completed successfully")
+    }
+}
+
+// MARK: - Logging
+
+private extension PersistentMigratorFromV2 {
+
+    /// Logs a message with the PersistentMigratorFromV2 prefix
+    func log(_ message: String) {
+        print("PersistentMigratorFromV2: \(message)")
+    }
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/SwiftUIExampleApp.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/SwiftUIExampleApp.swift
@@ -36,6 +36,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Uncomment the below line to migrate persisted values from iOS V1 SDK to Swift SDK
 //         PersistentMigratorFromV1(writeKey: "swift-sdk-write-key").restorePersistence()
         
+        // Uncomment the below line to migrate persisted values from iOS V2 SDK to Swift SDK
+//         PersistentMigratorFromV2(writeKey: "swift-sdk-write-key").restorePersistence()
+        
         self.permissionManager.requestPermissions([.idfa, .pushNotification, .bluetooth]) {
             print("All required permissions requested..")
             self.permissionsRequested = true


### PR DESCRIPTION
## Description
This pull request adds comprehensive migration support for the RudderStack iOS SDK V2, enabling seamless transition of user data from the legacy V2 SDK to the new Swift SDK. The migrator extracts user identities, traits, session information, and application metadata from `UserDefaults.standard` where V2 stored its data and transforms it into the Swift SDK's storage format.

The migration system ensures data continuity for users upgrading from V2 to the Swift SDK without losing critical analytics data like user IDs, anonymous IDs, user traits, active sessions, and application version information.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Added `PersistentMigratorFromV2` class**: Main migration orchestrator that reads V2 data from UserDefaults.standard and writes to Swift SDK's UserDefaults suite
- **Added `MigrationUtilsV2` utilities**: Helper methods for JSON encoding/decoding, timestamp conversions, UserDefaults operations, and anonymous ID generation (using device identifierForVendor/MAC address)
- **Added `LegacyDataV2` data models**: Structured representation of V2 SDK data including user identities, session data, and application information
- **Integrated migration in SwiftUIExample**: Added example usage with commented migration call in AppDelegate
- **Cross-platform anonymous ID support**: Handles iOS/tvOS (identifierForVendor), watchOS (WKInterfaceDevice), and macOS (MAC address) for anonymous ID generation

### Key Features:
- **Safe migration**: Checks for existing Swift SDK data and aborts if found to prevent overwriting
- **Timestamp conversion**: Converts V2's wall-clock timestamps to Swift SDK's system uptime format with boot-time validation
- **Data cleansing**: Removes duplicate ID fields from traits and validates data integrity before migration
- **Legacy cleanup**: Automatically removes V2 data after successful migration
- **Cross-platform support**: Works on iOS, tvOS, watchOS, and macOS

### Data Migration Coverage:
- Anonymous ID (derived from device identifierForVendor)
- User ID and traits
- Session ID, manual session tracking flag, and last activity time
- Application version and build number

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
### Manual Testing:
1. Install and run RudderStack iOS SDK V2 in an app to generate legacy data
2. Add the migration code to your app initialization:
   ```swift
   let migrator = PersistentMigratorFromV2(writeKey: "your_write_key")
   migrator.restorePersistence()
   ```
3. Initialize the Swift SDK and verify that user data (anonymousId, userId, traits, session info) is preserved
4. Confirm that legacy V2 data is cleaned up after successful migration

### Test Cases Added:
- Unit tests for migration utilities including JSON encoding/decoding
- Tests for timestamp conversion logic and edge cases (device reboot scenarios)
- Tests for anonymous ID generation across different platforms
- Integration tests for complete migration workflow
- Tests for data validation and cleanup processes

### Edge Case Testing:
- Device reboot scenarios (timestamp conversion should fail gracefully)
- Missing or corrupted V2 data (migration should handle gracefully)
- Existing Swift SDK data (migration should be skipped)
- Cross-platform anonymous ID generation

## Breaking Changes
None. This is a purely additive feature that doesn't modify existing functionality. The migration is opt-in and must be explicitly called by developers.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is a data migration feature without UI components.

## Additional Context
This migration system complements the existing V1 migrator (`PersistentMigratorFromV1`) and follows the same architectural patterns for consistency. The V2 migrator handles the specific differences in how V2 SDK stored data:

- V2 used only UserDefaults.standard (no custom suites)
- V2 didn't store anonymousId explicitly (derived from device identifier)
- V2 used wall-clock timestamps instead of system uptime
- V2 had different key naming conventions

The migrator is designed to be called once during app initialization before Swift SDK setup, similar to the V1 migrator pattern. It includes comprehensive logging for debugging and supports inspection of legacy data before migration via the `readPersistence()` method.

### Migration Safety:
- Idempotent operation (safe to call multiple times)
- Validates data integrity before and after migration
- Preserves original data until migration completion
- Comprehensive error handling and logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic migration from V2 persistence to the Swift SDK: transfers anonymous/user IDs, traits, session details, and app metadata into the new storage with safety checks and cleanup after successful migration.
* **Documentation**
  * Added developer-facing comments explaining V2→Swift migration flow (no runtime behavior changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->