### PR TITLE
feat: update event filtering plugin

### DIFF
--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h
@@ -11,29 +11,37 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- A plugin that filters out specific events from being processed by the analytics pipeline.
- 
+ This plugin filters out specific analytics events from being processed in the analytics pipeline.
+ It allows you to prevent certain track events from being tracked or sent to destinations.
+
  By default, this plugin filters out "Application Opened" and "Application Backgrounded" events.
- This is useful for reducing noise in analytics data by excluding automated lifecycle events
- that may not be relevant for your specific use case.
- 
- **Note**: Filtered events are completely removed from the processing pipeline and will not be sent to any destinations.
- 
- Set this plugin just after the SDK initialization to start filtering events:
- ```objective-c
+ You can also provide a custom list of event names to filter using `initWithEventsToFilter:`.
+
+ @code
+ // Using default filter list
  [analytics add:[[EventFilteringPlugin alloc] init]];
- ```
- 
- The plugin logs when events are filtered for debugging purposes.
+
+ // Using a custom filter list
+ NSArray *eventsToFilter = @[@"Event 1", @"Event 2"];
+ [analytics add:[[EventFilteringPlugin alloc] initWithEventsToFilter:eventsToFilter]];
+ @endcode
  */
 @interface EventFilteringPlugin : NSObject<RSSPlugin>
 
 /**
- Initializes the EventFilteringPlugin with default filtering rules.
-  
- @return An initialized EventFilteringPlugin instance
+ Initializes the plugin with the default filter list: "Application Opened" and "Application Backgrounded".
+
+ @return An initialized EventFilteringPlugin instance.
  */
 - (instancetype)init;
+
+/**
+ Initializes the plugin with a custom list of event names to filter out.
+
+ @param eventsToFilter An array of event names that should be filtered from the analytics pipeline.
+ @return An initialized EventFilteringPlugin instance.
+ */
+- (instancetype)initWithEventsToFilter:(NSArray<NSString *> *)eventsToFilter;
 
 @end
 

--- a/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
+++ b/Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m
@@ -11,10 +11,10 @@
 
 @interface EventFilteringPlugin()
 
-/// Reference to the analytics client
+/// The analytics instance this plugin is attached to.
 @property(nonatomic, retain) RSSAnalytics *client;
 
-/// Array of event names that should be filtered out
+/// The list of event names that should be filtered out from the analytics pipeline.
 @property(nonatomic, retain) NSMutableArray *eventsToFilter;
 
 @end
@@ -25,7 +25,15 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        // Initialize with default events to filter
+        self.eventsToFilter = [NSMutableArray arrayWithArray: @[@"Application Opened", @"Application Backgrounded"]];
+    }
+    return self;
+}
+
+- (instancetype)initWithEventsToFilter:(NSArray<NSString *> *)eventsToFilter {
+    self = [super init];
+    if (self) {
+        self.eventsToFilter = [NSMutableArray arrayWithArray:eventsToFilter];
     }
     return self;
 }
@@ -36,15 +44,13 @@
 
 - (void)setup:(RSSAnalytics * _Nonnull)analytics {
     self.client = analytics;
-    // Set up default events to filter - Application lifecycle events that are often noise
-    self.eventsToFilter = [NSMutableArray arrayWithArray: @[@"Application Opened", @"Application Backgrounded"]];
 }
 
 /**
- Intercepts events and filters out unwanted events based on the configured filter list.
- 
- @param event The event to potentially filter
- @return The original event if it should pass through, or nil if it should be filtered out
+ Intercepts analytics events and filters out specified track events.
+
+ @param event The event to potentially filter.
+ @return The original event if it should be processed, or nil if it should be filtered out.
  */
 - (RSSEvent * _Nullable)intercept:(RSSEvent * _Nonnull)event {
     if ([event isKindOfClass:[RSSTrackEvent class]]) {
@@ -59,17 +65,15 @@
 
 /**
  Determines whether a track event should be filtered based on its event name.
- 
- @param trackEvent The track event to evaluate
- @return YES if the event should be filtered out, NO if it should pass through
+
+ @param trackEvent The track event to evaluate.
+ @return YES if the event should be filtered out, NO if it should pass through.
  */
 - (BOOL)shouldFilterEvent:(RSSTrackEvent *)trackEvent {
     return [self.eventsToFilter containsObject:trackEvent.eventName];
 }
 
-/**
- Cleans up resources when the plugin is being removed or the analytics client is shutting down.
- */
+/** Called when the plugin is being removed or the analytics instance is being torn down. */
 - (void)teardown {
     [self.eventsToFilter removeAllObjects];
     self.eventsToFilter = nil;

--- a/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift
@@ -14,21 +14,33 @@ import RudderStackAnalytics
  
  ## Usage:
  ```swift
- // Create and add the plugin
+ // Create and add the plugin with default filtering (filters "Application Opened" and "Application Backgrounded")
  let eventFilteringPlugin = EventFilteringPlugin()
  analytics.add(plugin: eventFilteringPlugin)
+ 
+ // Or create with custom events to filter
+ let customEventFilteringPlugin = EventFilteringPlugin(eventsToFilter: ["Custom Event", "Unwanted Event", "Test Event"])
+ analytics.add(plugin: customEventFilteringPlugin)
  ```
 */
 final class EventFilteringPlugin: Plugin {
     var pluginType: PluginType = .onProcess
     var analytics: Analytics?
     
-    private var eventsToFilter = [String]()
+    private let eventsToFilter: [String]
+    
+    /** 
+     Initializes the EventFilteringPlugin with events to filter
+     
+     - Parameter eventsToFilter: Array of event names to filter out. Defaults to ["Application Opened", "Application Backgrounded"]
+     */
+    init(eventsToFilter: [String] = ["Application Opened", "Application Backgrounded"]) {
+        self.eventsToFilter = eventsToFilter
+    }
     
     /** Called when the plugin is added to the analytics instance */
     func setup(analytics: Analytics) {
         self.analytics = analytics
-        self.eventsToFilter = ["Application Opened", "Application Backgrounded"]
     }
     
     /** 
@@ -43,10 +55,5 @@ final class EventFilteringPlugin: Plugin {
             return nil
         }
         return event
-    }
-    
-    /** Called when the plugin is being removed or the analytics instance is being torn down */
-    func teardown() {
-        self.eventsToFilter.removeAll()
     }
 }

--- a/Examples/SwiftUIExample/SwiftUIExampleTests/EventFilteringPluginTests.swift
+++ b/Examples/SwiftUIExample/SwiftUIExampleTests/EventFilteringPluginTests.swift
@@ -17,7 +17,7 @@ struct EventFilteringPluginTests {
     
     @Test
     func test_whenEventShouldBeFiltered() {
-        given("An EventFilteringPlugin initialized") {
+        given("An EventFilteringPlugin initialized with default events") {
             let analytics = Analytics(configuration: self.testConfiguration)
             let plugin = EventFilteringPlugin()
             plugin.setup(analytics: analytics)
@@ -35,7 +35,7 @@ struct EventFilteringPluginTests {
     
     @Test
     func test_whenEventShouldNotBeFiltered() {
-        given("An EventFilteringPlugin initialized") {
+        given("An EventFilteringPlugin initialized with default events") {
             let analytics = Analytics(configuration: self.testConfiguration)
             let plugin = EventFilteringPlugin()
             plugin.setup(analytics: analytics)
@@ -58,7 +58,7 @@ struct EventFilteringPluginTests {
     
     @Test
     func test_whenMultipleEventsAreFiltered() {
-        given("An EventFilteringPlugin initialized") {
+        given("An EventFilteringPlugin initialized with default events") {
             let analytics = Analytics(configuration: self.testConfiguration)
             let plugin = EventFilteringPlugin()
             plugin.setup(analytics: analytics)
@@ -80,7 +80,7 @@ struct EventFilteringPluginTests {
     
     @Test
     func test_whenNonTrackEventIsIntercepted() {
-        given("An EventFilteringPlugin initialized") {
+        given("An EventFilteringPlugin initialized with default events") {
             let analytics = Analytics(configuration: self.testConfiguration)
             let plugin = EventFilteringPlugin()
             plugin.setup(analytics: analytics)
@@ -92,6 +92,79 @@ struct EventFilteringPluginTests {
                 then("The event should pass through unchanged") {
                     #expect(result != nil)
                     #expect(result?.type == .track)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenCustomEventsAreFiltered() {
+        given("An EventFilteringPlugin initialized with custom events to filter") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let customEvents = ["Custom Event", "Unwanted Event"]
+            let plugin = EventFilteringPlugin(eventsToFilter: customEvents)
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting TrackEvents with custom filtered event names") {
+                let filteredEvent1 = TrackEvent(event: "Custom Event")
+                let filteredEvent2 = TrackEvent(event: "Unwanted Event")
+                let allowedEvent = TrackEvent(event: "Application Opened") // Default event but not in custom list
+                
+                let result1 = plugin.intercept(event: filteredEvent1)
+                let result2 = plugin.intercept(event: filteredEvent2)
+                let result3 = plugin.intercept(event: allowedEvent)
+                
+                then("Custom events should be filtered out, default events should pass through") {
+                    #expect(result1 == nil)
+                    #expect(result2 == nil)
+                    #expect(result3 != nil)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenEmptyCustomEventsListIsProvided() {
+        given("An EventFilteringPlugin initialized with empty events list") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin(eventsToFilter: [])
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting any TrackEvent") {
+                let event1 = TrackEvent(event: "Application Opened")
+                let event2 = TrackEvent(event: "Any Event")
+                
+                let result1 = plugin.intercept(event: event1)
+                let result2 = plugin.intercept(event: event2)
+                
+                then("All events should pass through since nothing is filtered") {
+                    #expect(result1 != nil)
+                    #expect(result2 != nil)
+                }
+            }
+        }
+    }
+    
+    @Test
+    func test_whenSingleCustomEventIsFiltered() {
+        given("An EventFilteringPlugin initialized with single custom event") {
+            let analytics = Analytics(configuration: self.testConfiguration)
+            let plugin = EventFilteringPlugin(eventsToFilter: ["Specific Event"])
+            plugin.setup(analytics: analytics)
+            
+            when("Intercepting the specific event and other events") {
+                let filteredEvent = TrackEvent(event: "Specific Event")
+                let allowedEvent1 = TrackEvent(event: "Application Opened")
+                let allowedEvent2 = TrackEvent(event: "Product Purchased")
+                
+                let result1 = plugin.intercept(event: filteredEvent)
+                let result2 = plugin.intercept(event: allowedEvent1)
+                let result3 = plugin.intercept(event: allowedEvent2)
+                
+                then("Only the specific event should be filtered out") {
+                    #expect(result1 == nil)
+                    #expect(result2 != nil)
+                    #expect(result3 != nil)
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR enhances the EventFilteringPlugin in both Swift and Objective-C examples by adding customizable event filtering functionality. Previously, the plugin only supported filtering hardcoded default events ("Application Opened" and "Application Backgrounded"). The enhancement allows developers to provide their own custom list of events to filter, making the plugin more flexible and reusable for different use cases.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
- **Objective-C EventFilteringPlugin**: Added new `initWithEventsToFilter:` initializer method that accepts a custom array of event names to filter
- **Swift EventFilteringPlugin**: Modified the existing initializer to accept an optional `eventsToFilter` parameter with default values
- **Code refactoring**: Moved event filter list initialization from `setup:` method to initializers for better encapsulation
- **Documentation updates**: Enhanced header documentation with usage examples and clearer descriptions
- **Test coverage**: Added comprehensive test cases for the new custom filtering functionality including edge cases
- **Architecture improvement**: Made `eventsToFilter` property immutable (`let`) in Swift version for better thread safety
- **Cleanup**: Removed unnecessary `teardown` method in Swift implementation

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Default behavior test**: Initialize the plugin without parameters and verify it filters "Application Opened" and "Application Backgrounded" events
2. **Custom filtering test**: Initialize the plugin with a custom array of event names and verify only those events are filtered
3. **Empty filter test**: Initialize with an empty array and verify no events are filtered
4. **Single event test**: Initialize with a single event name and verify only that specific event is filtered
5. **Non-track event test**: Send non-track events (like IdentifyEvent) and verify they pass through unfiltered
6. **Multiple event test**: Send multiple track events with mixed filtered/allowed names and verify correct filtering behavior

Run the existing test suite:
- Execute `EventFilteringPluginTests.swift` test cases to verify all functionality works correctly
- Test both Swift and Objective-C implementations in their respective example projects

## Breaking Changes
None - This is a non-breaking change. The existing default behavior is preserved when no custom events are specified.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This change involves plugin functionality without UI components.

## Additional Context
This enhancement improves the reusability of the EventFilteringPlugin by allowing developers to customize which events to filter based on their specific analytics requirements. The change maintains backward compatibility while providing the flexibility needed for different use cases.

**Files modified:**
- `Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.h`
- `Examples/ObjCExample/ObjCExample/CustomPlugins/EventFilteringPlugin/EventFilteringPlugin.m`
- `Examples/SwiftUIExample/SwiftUIExample/CustomPlugins/EventFilteringPlugin.swift`
- `Examples/SwiftUIExample/SwiftUIExampleTests/EventFilteringPluginTests.swift`

**Key architectural improvements:**
- Better separation of concerns with filter list initialization moved to constructors
- Immutable event filter list in Swift implementation for thread safety
- More comprehensive test coverage including edge cases
- Enhanced documentation with practical usage examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event filtering plugin now supports configuration with custom event filter lists, featuring predefined defaults for common application events.

* **Tests**
  * Added comprehensive test coverage for custom event filtering across multiple scenarios, including empty filter lists and single-event filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->