### PR TITLE
fix: ensure EventUploader stops processing when upload channel is closed

### DIFF
--- a/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
+++ b/Sources/RudderStackAnalytics/EventQueue/EventUploader.swift
@@ -39,7 +39,7 @@ final class EventUploader {
                 let dataItems = await self.storage.read().dataItems
                 for item in dataItems {
                     // Check shutdown conditions before processing each item
-                    if self.analytics.isAnalyticsShutdown { break }
+                    if self.analytics.isAnalyticsShutdown || self.uploadChannel.isClosed { break }
                     
                     // Read the event batch from storage
                     let batch = self.analytics.storage.eventStorageMode == .memory ? item.batch : (FileManager.contentsOf(file: item.reference) ?? .empty)

--- a/Sources/RudderStackAnalytics/Helpers/CoreSupport/AsyncChannel.swift
+++ b/Sources/RudderStackAnalytics/Helpers/CoreSupport/AsyncChannel.swift
@@ -23,7 +23,10 @@ final class AsyncChannel<Element> {
     /**
      Indicates whether the channel is closed.
      */
-    private(set) var isClosed = false
+    var isClosed: Bool {
+        lock.withLock { _isClosed }
+    }
+    private var _isClosed = false
     
     /**
      Creates a new async channel.
@@ -48,7 +51,7 @@ final class AsyncChannel<Element> {
         lock.lock()
         defer { lock.unlock() }
         
-        guard !isClosed else {
+        guard !_isClosed else {
             throw ChannelError.closed
         }
         
@@ -71,8 +74,8 @@ final class AsyncChannel<Element> {
         lock.lock()
         defer { lock.unlock() }
         
-        guard !isClosed else { return }
-        isClosed = true
+        guard !_isClosed else { return }
+        _isClosed = true
         continuation?.finish()
         continuation = nil
     }


### PR DESCRIPTION
## Description
This PR fixes an issue in the `EventUploader` where it would continue processing queued batches even when the upload channel was closed. The bug occurred because the shutdown condition only checked `analytics.isAnalyticsShutdown` but ignored the state of the upload channel itself.

The fix adds an additional check for `uploadChannel.isClosed` to the existing shutdown condition, ensuring that event processing stops immediately when either the analytics is shutdown OR the upload channel is closed. This prevents unnecessary processing and potential resource waste when the uploader can no longer function.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Modified EventUploader.swift**: Enhanced the shutdown condition in the batch processing loop to check both `analytics.isAnalyticsShutdown` and `uploadChannel.isClosed`
- **Added comprehensive test**: Created `testStopsProcessingRemainingBatchesAfterNonRetryableError()` to verify the fix works correctly with multiple batches and error scenarios
- **Test scenario**: The test simulates a retryable error followed by a non-retryable error, ensuring the uploader stops processing remaining batches after the channel is closed

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Run the new test**: Execute `testStopsProcessingRemainingBatchesAfterNonRetryableError()` to verify the fix
2. **Test scenario**: The test creates multiple batches, simulates network responses (502 retryable error, then 404 non-retryable error), and verifies:
   - Upload channel gets closed after non-retryable error
   - Only 2 upload attempts are made (one retryable retry, then failure)
   - Processing stops without attempting remaining batches
3. **Integration testing**: Test with actual network failures to ensure upload processing stops appropriately when the channel is closed

## Breaking Changes
None. This is a backward-compatible bug fix that improves the robustness of the EventUploader.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
Not applicable - this is a logic fix without UI changes.

## Additional Context
This fix addresses a potential resource leak where the EventUploader could continue attempting to process batches even after the upload channel was closed due to unrecoverable errors. The enhanced shutdown condition ensures more predictable and efficient behavior during error scenarios.

**Files changed:**
- `Sources/RudderStackAnalytics/EventQueue/EventUploader.swift` - Enhanced shutdown condition
- `Tests/RudderStackAnalyticsTests/EventsModule/EventProcessing/EventUploaderTests.swift` - Added comprehensive test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event uploader now reliably stops processing remaining batches when shutdown or upload channels close, and properly halts on non-retryable upload errors.
* **Tests**
  * Added tests verifying processing stops after a non-retryable error and that upload channels close as expected.
* **Refactor**
  * Improved channel state handling for safer, thread‑aware closed-state access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->