### PR TITLE
feat: use system time in session management

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/MigrationUtilsV1.swift
@@ -179,51 +179,21 @@ enum MigrationUtilsV1 {
     // MARK: - Timestamp Conversion
     
     /**
-     Converts a legacy wall-clock timestamp (timeIntervalSince1970) into a
-     system uptime value (ProcessInfo.processInfo.systemUptime) expressed
-     in milliseconds.
+     Converts a legacy wall-clock timestamp (timeIntervalSince1970 in seconds) into
+     milliseconds for the new SDK format.
      
      This method is used during SDK migration where the legacy SDK stored
-     the last activity time as an absolute timestamp, while the new SDK
-     stores it as system uptime (time since last device boot).
-     
-     Conversion logic:
-     - Read the current timestamp (t_now)
-     - Read the current system uptime (u_now)
-     - Calculate the system boot timestamp:
-     bootTimestamp = t_now - u_now
-     - Calculate the uptime at which the legacy event occurred:
-     uptimeAtTimestamp = legacyTimestamp - bootTimestamp
-     
-     If the legacy timestamp occurred before the current system boot,
-     the conversion is not possible and the method returns nil.
-     
-     Example:
-     currentTimestamp = 1_725_000_000   (seconds since 1970)
-     currentUptime    = 10_000          (seconds since last boot)
-     
-     bootTimestamp    = 1_724_990_000
-     
-     legacyTimestamp  = 1_724_995_000
-     
-     uptimeAtTimestamp = 5_000 seconds
-     result            = 5_000_000 milliseconds
-     
-     Important notes:
-     - This conversion only succeeds if the device has not rebooted since
-     the legacy timestamp was recorded.
-     - If a reboot occurred, returning nil is the correct and safe behavior.
+     the last activity time as seconds since 1970, while the new SDK
+     stores it as milliseconds since 1970.
      
      - Parameter timestamp:
-     Legacy timestamp represented as timeIntervalSince1970.
+     Legacy timestamp represented as timeIntervalSince1970 (seconds).
      
      - Returns:
-     System uptime in milliseconds corresponding to the legacy timestamp,
-     or nil if the conversion is not valid.
+     Timestamp in milliseconds, or nil if the timestamp is invalid.
      */
-    static func convertTimestampToSystemUptime(_ timestamp: Double) -> UInt64? {
+    static func convertTimestampToMilliseconds(_ timestamp: Double) -> UInt64? {
         let currentTimestamp = Date().timeIntervalSince1970
-        let currentUptime = ProcessInfo.processInfo.systemUptime
         
         // Timestamp must be valid and in the past
         guard timestamp > 0, timestamp <= currentTimestamp else {
@@ -231,18 +201,8 @@ enum MigrationUtilsV1 {
             return nil
         }
         
-        // Calculate system boot time as a timestamp
-        let bootTimestamp = currentTimestamp - currentUptime
-        
-        // Calculate uptime at the time of the legacy timestamp
-        let uptimeAtTimestamp = timestamp - bootTimestamp
-        guard uptimeAtTimestamp >= 0 else {
-            print("MigrationUtilsV1: Timestamp predates system boot: \(timestamp)")
-            return nil
-        }
-        
         // Convert seconds to milliseconds
-        return UInt64(uptimeAtTimestamp * 1000)
+        return UInt64(timestamp * 1000)
     }
 }
 

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV1/PersistentMigratorFromV1.swift
@@ -232,7 +232,7 @@ private extension PersistentMigratorFromV1 {
             return nil
         }
 
-        guard let convertedTime = MigrationUtilsV1.convertTimestampToSystemUptime(timestampNumber.doubleValue) else {
+        guard let convertedTime = MigrationUtilsV1.convertTimestampToMilliseconds(timestampNumber.doubleValue) else {
             log("Failed to convert lastEventTimeStamp - session timing may be affected")
             return nil
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/MigrationUtilsV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/MigrationUtilsV2.swift
@@ -160,40 +160,21 @@ enum MigrationUtilsV2 {
     // MARK: - Timestamp Conversion
     
     /**
-     Converts a legacy wall-clock timestamp (timeIntervalSince1970) into a
-     system uptime value (ProcessInfo.processInfo.systemUptime) expressed
-     in milliseconds.
+     Converts a legacy wall-clock timestamp (timeIntervalSince1970 in seconds) into
+     milliseconds for the new SDK format.
      
      This method is used during SDK migration where the legacy SDK stored
-     the last activity time as an absolute timestamp, while the new SDK
-     stores it as system uptime (time since last device boot).
-     
-     Conversion logic:
-     - Read the current timestamp (t_now)
-     - Read the current system uptime (u_now)
-     - Calculate the system boot timestamp:
-     bootTimestamp = t_now - u_now
-     - Calculate the uptime at which the legacy event occurred:
-     uptimeAtTimestamp = legacyTimestamp - bootTimestamp
-     
-     If the legacy timestamp occurred before the current system boot,
-     the conversion is not possible and the method returns nil.
-     
-     Important notes:
-     - This conversion only succeeds if the device has not rebooted since
-     the legacy timestamp was recorded.
-     - If a reboot occurred, returning nil is the correct and safe behavior.
+     the last activity time as seconds since 1970, while the new SDK
+     stores it as milliseconds since 1970.
      
      - Parameter timestamp:
-     Legacy timestamp represented as timeIntervalSince1970.
+     Legacy timestamp represented as timeIntervalSince1970 (seconds).
      
      - Returns:
-     System uptime in milliseconds corresponding to the legacy timestamp,
-     or nil if the conversion is not valid.
+     Timestamp in milliseconds, or nil if the timestamp is invalid.
      */
-    static func convertTimestampToSystemUptime(_ timestamp: Double) -> UInt64? {
+    static func convertTimestampToMilliseconds(_ timestamp: Double) -> UInt64? {
         let currentTimestamp = Date().timeIntervalSince1970
-        let currentUptime = ProcessInfo.processInfo.systemUptime
         
         // Timestamp must be valid and in the past
         guard timestamp > 0, timestamp <= currentTimestamp else {
@@ -201,18 +182,8 @@ enum MigrationUtilsV2 {
             return nil
         }
         
-        // Calculate system boot time as a timestamp
-        let bootTimestamp = currentTimestamp - currentUptime
-        
-        // Calculate uptime at the time of the legacy timestamp
-        let uptimeAtTimestamp = timestamp - bootTimestamp
-        guard uptimeAtTimestamp >= 0 else {
-            print("MigrationUtilsV2: Timestamp predates system boot: \(timestamp)")
-            return nil
-        }
-        
         // Convert seconds to milliseconds
-        return UInt64(uptimeAtTimestamp * 1000)
+        return UInt64(timestamp * 1000)
     }
     
     // MARK: - Anonymous ID Retrieval

--- a/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/PersistenceMigrator/FromV2/PersistentMigratorFromV2.swift
@@ -220,7 +220,7 @@ private extension PersistentMigratorFromV2 {
             return nil
         }
 
-        guard let convertedTime = MigrationUtilsV2.convertTimestampToSystemUptime(timestampNumber.doubleValue) else {
+        guard let convertedTime = MigrationUtilsV2.convertTimestampToMilliseconds(timestampNumber.doubleValue) else {
             log("Failed to convert lastEventTimeStamp - session timing may be affected")
             return nil
         }

--- a/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
+++ b/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
@@ -156,7 +156,6 @@ extension SessionHandler {
         }
         
         let timeDifference = currentTime - self.lastActivityTime
-        print("Vishal123, currentTime: \(currentTime), lastActivityTime: \(self.lastActivityTime), timeDifference: \(timeDifference)")
         
         return timeDifference > self.automaticSessionTimeout
     }
@@ -187,7 +186,6 @@ extension SessionHandler {
     
     func updateSessionLastActivityTime(_ time: UInt64? = nil) {
         let lastActivityTime = time ?? self.systemCurrentTime
-        print("Vishal123: updating session last activity time: \(lastActivityTime)")
         self.sessionState.dispatch(action: UpdateSessionLastActivityAction(lastActivityTime: lastActivityTime))
         self.sessionInstance.storeSessionActivity(time: lastActivityTime, storage: self.storage)
     }

--- a/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
+++ b/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
@@ -127,13 +127,37 @@ extension SessionHandler {
         return self.sessionInstance.lastActivityTime
     }
     
-    var monotonicCurrentTime: UInt64 {
+    var systemCurrentTime: UInt64 {
         let millisecondsInSecond: TimeInterval = 1000.0
-        return UInt64(ProcessInfo.processInfo.systemUptime * millisecondsInSecond)
+        return UInt64(Date().timeIntervalSince1970 * millisecondsInSecond)
     }
     
+    /**
+     Determines if the current session has timed out.
+     
+     A session is considered timed out if the elapsed time since the last recorded
+     activity exceeds the configured session timeout.
+     
+     This method uses system current time. If the current system
+     time is less than or equal to the last activity time, it indicates that the clock has been tampered with.
+     In such cases, the session is treated as expired.
+     
+     - Returns: `true` if the session has timed out, `false` otherwise.
+     */
     var isSessionTimedOut: Bool {
-        let timeDifference = self.monotonicCurrentTime &- self.lastActivityTime // Safe subtraction
+        let currentTime = self.systemCurrentTime
+        
+        if currentTime <= self.lastActivityTime {
+            LoggerAnalytics.warn(
+                "Current system time is less than or equal to last activity time." +
+                " This indicates potential clock tampering. Resetting the session"
+            )
+            return true
+        }
+        
+        let timeDifference = currentTime - self.lastActivityTime
+        print("Vishal123, currentTime: \(currentTime), lastActivityTime: \(self.lastActivityTime), timeDifference: \(timeDifference)")
+        
         return timeDifference > self.automaticSessionTimeout
     }
 }
@@ -162,7 +186,8 @@ extension SessionHandler {
     }
     
     func updateSessionLastActivityTime(_ time: UInt64? = nil) {
-        let lastActivityTime = time ?? self.monotonicCurrentTime
+        let lastActivityTime = time ?? self.systemCurrentTime
+        print("Vishal123: updating session last activity time: \(lastActivityTime)")
         self.sessionState.dispatch(action: UpdateSessionLastActivityAction(lastActivityTime: lastActivityTime))
         self.sessionInstance.storeSessionActivity(time: lastActivityTime, storage: self.storage)
     }

--- a/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
+++ b/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
@@ -129,7 +129,8 @@ extension SessionHandler {
     
     var systemCurrentTime: UInt64 {
         let millisecondsInSecond: TimeInterval = 1000.0
-        return UInt64(Date().timeIntervalSince1970 * millisecondsInSecond)
+        let interval = Date().timeIntervalSince1970
+        return interval > 0 ? UInt64(interval * millisecondsInSecond) : 0
     }
     
     /**

--- a/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
@@ -374,9 +374,11 @@ struct SessionHandlerTests {
         #expect(sessionHandler.sessionType == .manual)
         #expect(sessionHandler.isSessionStart)
         
-        // Update activity
-        sessionHandler.updateSessionLastActivityTime()
-        
+        // Update activity with a known recent past time so that systemCurrentTime
+        // is strictly greater when isSessionTimedOut evaluates it.
+        let recentActivityTime = sessionHandler.systemCurrentTime - 1000
+        sessionHandler.updateSessionLastActivityTime(recentActivityTime)
+
         // Activity updated
         #expect(sessionHandler.lastActivityTime > 0)
         #expect(!sessionHandler.isSessionTimedOut)
@@ -425,6 +427,20 @@ struct SessionHandlerTests {
         // Should be automatic
         #expect(sessionHandler.sessionType == .automatic)
         #expect(sessionHandler.sessionId == 2222222222)
+    }
+    
+    @Test("given a last activity time set to a future timestamp, when checking session timeout, then it should be considered timed out due to clock tampering")
+    func testSessionTimedOutWhenLastActivityTimeIsInFuture() {
+        let configuration = SessionConfiguration(automaticSessionTracking: true, sessionTimeoutInMillis: 5000)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
+        let sessionHandler = SessionHandler(analytics: analytics)
+
+        // Simulate a last activity time that is 1 minute ahead of now,
+        // as would happen if the system clock was moved backward after the time was stored.
+        let futureTime = sessionHandler.systemCurrentTime + 60000
+        sessionHandler.updateSessionLastActivityTime(futureTime)
+
+        #expect(sessionHandler.isSessionTimedOut)
     }
 }
 

--- a/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
@@ -223,7 +223,7 @@ struct SessionHandlerTests {
         storage.write(value: String(initialSessionId), key: Constants.storageKeys.sessionId)
         storage.write(value: false, key: Constants.storageKeys.isManualSession)
         // Simulate last activity 10 seconds ago (past timeout of 5 seconds)
-        let pastTime = UInt64(ProcessInfo.processInfo.systemUptime * 1000) - 10000
+        let pastTime = UInt64(Date().timeIntervalSince1970 * 1000) - 10000
         storage.write(value: String(pastTime), key: Constants.storageKeys.lastActivityTime)
         
         let sessionHandler = SessionHandler(analytics: analytics)
@@ -295,7 +295,7 @@ struct SessionHandlerTests {
         let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
         let sessionHandler = SessionHandler(analytics: analytics)
         
-        let pastTime = sessionHandler.monotonicCurrentTime - timeDifferenceMs
+        let pastTime = sessionHandler.systemCurrentTime - timeDifferenceMs
         sessionHandler.updateSessionLastActivityTime(pastTime)
         
         #expect(sessionHandler.isSessionTimedOut == expectedTimedOut)
@@ -319,13 +319,13 @@ struct SessionHandlerTests {
         let sessionHandler = SessionHandler(analytics: analytics)
         
         let testTime: UInt64 = 1234567890
-        let beforeTime = sessionHandler.monotonicCurrentTime
+        let beforeTime = sessionHandler.systemCurrentTime
         
         sessionHandler.updateSessionLastActivityTime(testTime)
         #expect(sessionHandler.lastActivityTime == testTime)
         
         sessionHandler.updateSessionLastActivityTime()
-        let afterTime = sessionHandler.monotonicCurrentTime
+        let afterTime = sessionHandler.systemCurrentTime
         
         #expect(sessionHandler.lastActivityTime >= beforeTime)
         #expect(sessionHandler.lastActivityTime <= afterTime)
@@ -343,7 +343,7 @@ struct SessionHandlerTests {
         storage.write(value: String(previousSessionId), key: Constants.storageKeys.sessionId)
         storage.write(value: false, key: Constants.storageKeys.isManualSession)
         // Set last activity time to be beyond timeout
-        let pastTime = UInt64(ProcessInfo.processInfo.systemUptime * 1000) - 10000
+        let pastTime = UInt64(Date().timeIntervalSince1970 * 1000) - 10000
         storage.write(value: String(pastTime), key: Constants.storageKeys.lastActivityTime)
         
         let sessionHandler = SessionHandler(analytics: analytics)
@@ -355,30 +355,6 @@ struct SessionHandlerTests {
         try? await Task.sleep(nanoseconds: 100_000_000)
         
         #expect(sessionHandler.sessionId != previousSessionId)
-        #expect(sessionHandler.sessionType == .automatic)
-    }
-    
-    // MARK: - System Restart Tests
-    
-    @Test("given automatic session enabled and the system is restarted (monotonic time less than last activity), when app is launched, then new session starts")
-    func testSystemRestartOnLaunchStartsNewSession() {
-        let configuration = SessionConfiguration(automaticSessionTracking: true, sessionTimeoutInMillis: 300000)
-        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
-        let storage = analytics.configuration.storage
-        
-        let initialSessionId: UInt64 = 1234567890
-        // Current monotonic time will be small (since system just restarted)
-        // But last activity time was stored before restart, so it's larger
-        let veryLargeLastActivityTime: UInt64 = UInt64.max - 1000
-        
-        storage.write(value: String(initialSessionId), key: Constants.storageKeys.sessionId)
-        storage.write(value: false, key: Constants.storageKeys.isManualSession)
-        storage.write(value: String(veryLargeLastActivityTime), key: Constants.storageKeys.lastActivityTime)
-        
-        let sessionHandler = SessionHandler(analytics: analytics)
-        
-        // After system restart, monotonic time is small, so session should be timed out
-        #expect(sessionHandler.sessionId != initialSessionId)
         #expect(sessionHandler.sessionType == .automatic)
     }
     

--- a/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
@@ -358,32 +358,6 @@ struct SessionHandlerTests {
         #expect(sessionHandler.sessionType == .automatic)
     }
     
-    // MARK: - System Restart Tests
-    
-    @Test("given automatic session enabled and the system is restarted (monotonic time less than last activity), when app is launched, then new session starts")
-    func testSystemRestartOnLaunchStartsNewSession() {
-        let configuration = SessionConfiguration(automaticSessionTracking: true, sessionTimeoutInMillis: 300000)
-        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
-        let storage = analytics.configuration.storage
-        
-        let initialSessionId: UInt64 = 1234567890
-        // Simulate system restart: last activity time is slightly ahead of current monotonic time.
-        // With wrapping subtraction (monotonicCurrentTime &- lastActivityTime), this produces
-        // a very large value (close to UInt64.max), which exceeds the session timeout.
-        let currentMonotonicTime = UInt64(ProcessInfo.processInfo.systemUptime * 1000.0)
-        let veryLargeLastActivityTime: UInt64 = currentMonotonicTime + 1000
-        
-        storage.write(value: String(initialSessionId), key: Constants.storageKeys.sessionId)
-        storage.write(value: false, key: Constants.storageKeys.isManualSession)
-        storage.write(value: String(veryLargeLastActivityTime), key: Constants.storageKeys.lastActivityTime)
-        
-        let sessionHandler = SessionHandler(analytics: analytics)
-        
-        // After system restart, monotonic time is small, so session should be timed out
-        #expect(sessionHandler.sessionId != initialSessionId)
-        #expect(sessionHandler.sessionType == .automatic)
-    }
-    
     // MARK: - Integration Tests
     
     @Test("given a session configuration, when completing the session lifecycle, then it should transition through all states correctly")


### PR DESCRIPTION
## Description

This PR refactors the session timing mechanism in the SessionHandler to use system time instead of monotonic uptime and adds clock tampering detection. The change switches from `ProcessInfo.processInfo.systemUptime` to `Date().timeIntervalSince1970` for session timeout calculations and introduces safeguards to detect when the system clock has been manipulated (either moved backward or forward).

When the current system time is less than or equal to the last recorded activity time, the session is automatically expired and a warning is logged. This prevents sessions from persisting indefinitely due to clock manipulation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- **Renamed method**: `monotonicCurrentTime` → `systemCurrentTime` in SessionHandler
- **Changed time source**: From `ProcessInfo.processInfo.systemUptime` to `Date().timeIntervalSince1970` for all session timing calculations
- **Added clock tampering detection**: The `isSessionTimedOut` property now checks if the current time is less than or equal to the last activity time and treats this as a timed-out session
- **Added documentation**: Comprehensive inline documentation for the `isSessionTimedOut` computed property explaining the clock tampering detection logic
- **Added logging**: Warning log message when potential clock tampering is detected
- **Removed safe subtraction operator**: Changed from `&-` to `-` since clock tampering is now handled explicitly
- **Updated all test references**: Changed from `monotonicCurrentTime` to `systemCurrentTime` throughout the test suite
- **Removed obsolete test**: Deleted `testSystemRestartOnLaunchStartsNewSession()` which was testing the monotonic time restart behavior
- **Added new test**: `testSessionTimedOutWhenLastActivityTimeIsInFuture()` to verify clock tampering detection when the system clock is moved backward
- **Modified integration test**: Updated `testSessionLifecycle()` to use a specific past time to prevent race conditions in time comparisons

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

### Test Clock Tampering Detection
1. Run the test suite to verify all tests pass: `swift test`
2. Specifically verify the new test `testSessionTimedOutWhenLastActivityTimeIsInFuture()` passes
3. To manually test clock tampering detection:
   - Initialize a session with automatic tracking enabled
   - Record the last activity time
   - Manually set the system clock backward
   - Launch the app and verify that a new session is created (the old session should be treated as timed out)

### Test Normal Session Behavior
1. Verify that normal session timeout behavior still works correctly
2. Test that sessions expire properly after the configured timeout period
3. Verify that session activity updates work as expected with the new `systemCurrentTime` implementation

### Regression Testing
1. Run the full test suite to ensure no existing functionality is broken
2. Test automatic session tracking with various timeout configurations
3. Verify manual session management still functions correctly

## Breaking Changes

**Potential behavioral change**: Sessions now use absolute system time (`Date().timeIntervalSince1970`) instead of monotonic uptime (`ProcessInfo.processInfo.systemUptime`). This that device restart will not affect the session management now.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A - This PR contains backend logic changes only, no UI modifications.

## Additional Context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now use system wall-clock for timeout checks and expire if the device clock moves backward to guard against clock tampering.
* **Refactor**
  * Legacy timestamp conversion simplified: legacy values treated as seconds-since-1970 and converted to milliseconds.
* **Tests**
  * Added a test for clock-tampering behavior and removed a test that simulated system restart semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->