### PR TITLE
fix: resolve data race crash in network monitor during network path changes

### DIFF
--- a/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
@@ -56,11 +56,11 @@ protocol NetworkMonitorProtocol {
  */
 class NetworkMonitor: NetworkMonitorProtocol {
     private let monitor = NWPathMonitor()
-    private let semaphore = DispatchSemaphore(value: 0)
 
     init() {
-        monitor.pathUpdateHandler = { [weak self] _ in
-            self?.semaphore.signal()
+        let semaphore = DispatchSemaphore(value: 0)
+        monitor.pathUpdateHandler = { _ in
+            semaphore.signal()
         }
         let queue = DispatchQueue(label: "NetworkMonitor")
         monitor.start(queue: queue)

--- a/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
@@ -57,24 +57,22 @@ protocol NetworkMonitorProtocol {
 class NetworkMonitor: NetworkMonitorProtocol {
     private let monitor = NWPathMonitor()
     private let semaphore = DispatchSemaphore(value: 0)
-    private var path: NWPath?
-    
+
     init() {
-        monitor.pathUpdateHandler = { [weak self] path in
-            self?.path = path
+        monitor.pathUpdateHandler = { [weak self] _ in
             self?.semaphore.signal()
         }
         let queue = DispatchQueue(label: "NetworkMonitor")
         monitor.start(queue: queue)
         semaphore.wait()
     }
-    
+
     var status: NWPath.Status {
-        return path?.status ?? .unsatisfied
+        return monitor.currentPath.status
     }
-    
+
     func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool {
-        return path?.usesInterfaceType(type) ?? false
+        return monitor.currentPath.usesInterfaceType(type)
     }
     
     func start(queue: DispatchQueue) {


### PR DESCRIPTION
## Description
Fixes a data race crash caused by unsynchronized access to a mutable network path property. The property was written on the `NWPathMonitor` queue and read concurrently on the Swift cooperative thread pool, causing a crash (`EXC_BAD_ACCESS` via `objc_retain`) when the network path changed during foreground/background transitions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Removed the mutable `NWPath?` stored property from `NetworkMonitor`
- Reads now go directly to `monitor.currentPath`, which is `NWPathMonitor`'s own thread-safe property
- Eliminates shared mutable state entirely, making the race impossible

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
Existing `NetworkInfoPluginTests` cover the behaviour via `MockNetworkMonitor`. No test changes were required as the fix does not affect the `NetworkMonitorProtocol` interface. To further validate, run the test suite with Thread Sanitizer enabled while toggling network conditions — no data race should be reported.

## Breaking Changes
None. The fix is internal to `NetworkMonitor` and does not change any public or protocol interfaces.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A — no UI changes.

## Additional Context
The stack trace confirmed the race — `NWPathMonitor` firing a path update (`HTTP3Connection::connEventAlternatePathAvailable`) while analytics was concurrently reading the stored path during a foreground transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal network-monitoring logic simplified to rely on the monitor’s current state, improving reliability and responsiveness.
  * No changes to public APIs or external behavior; integrations and public interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->