### PR TITLE
chore(release): RudderStackAnalytics Swift SDK v1.2.1

### DIFF
--- a/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
@@ -218,5 +218,5 @@ public struct _DefaultConfig {
  **Important:**
  Do not edit this value unless performing a manual release.
  */
-let RSVersion: String = "1.2.0"
+let RSVersion: String = "1.2.1"
 let RSLibraryName: String = "rudder-sdk-swift"

--- a/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
@@ -56,25 +56,23 @@ protocol NetworkMonitorProtocol {
  */
 class NetworkMonitor: NetworkMonitorProtocol {
     private let monitor = NWPathMonitor()
-    private let semaphore = DispatchSemaphore(value: 0)
-    private var path: NWPath?
-    
+
     init() {
-        monitor.pathUpdateHandler = { [weak self] path in
-            self?.path = path
-            self?.semaphore.signal()
+        let semaphore = DispatchSemaphore(value: 0)
+        monitor.pathUpdateHandler = { _ in
+            semaphore.signal()
         }
         let queue = DispatchQueue(label: "NetworkMonitor")
         monitor.start(queue: queue)
         semaphore.wait()
     }
-    
+
     var status: NWPath.Status {
-        return path?.status ?? .unsatisfied
+        return monitor.currentPath.status
     }
-    
+
     func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool {
-        return path?.usesInterfaceType(type) ?? false
+        return monitor.currentPath.usesInterfaceType(type)
     }
     
     func start(queue: DispatchQueue) {


### PR DESCRIPTION
# RudderStack Swift SDK v1.2.1

## Fixes
- Data race crash in network monitor caused by concurrent reads and writes to the network path property during foreground/background transitions