### PR TITLE
chore(git-hooks): implement local pre-commit, commit-msg, and pre-push hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,12 @@ When creating branches, follow this naming pattern:
 <type>/<description>
 
 Examples:
-  feature/sdk-4614-add-session-tracking
+  feat/sdk-4614-add-session-tracking
   fix/session-timeout-crash
   chore/update-dependencies
 ```
 
-Allowed types: `feat`, `feature`, `fix`, `hotfix`, `refactor`, `release`, `docs`, `chore`, `test`, `ci`
+Allowed types: `feat`, `fix`, `hotfix`, `refactor`, `release`, `docs`, `chore`, `test`, `ci`
 
 #### Commit Message Convention
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ sh scripts/setup-hooks.sh
 
 When creating branches, follow this naming pattern:
 
-```
+```text
 <type>/<description>
 
 Examples:
@@ -263,7 +263,7 @@ Allowed types: `feat`, `feature`, `fix`, `hotfix`, `refactor`, `release`, `docs`
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
 
-```
+```text
 <type>(<optional scope>): <description>
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The Swift SDK enables you to track customer event data from your iOS, macOS, tvO
 - [Identifying users](#identifying-users)
 - [Tracking user actions](#tracking-user-actions)
 - [Integrations](#integrations)
+- [Development](#development)
 - [Contact us](#contact-us)
 - [Follow Us](#follow-us)
 
@@ -207,6 +208,68 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
+```
+
+---
+
+## Development
+
+This section provides information for developers contributing to the RudderStack Swift SDK.
+
+### Git Hooks
+
+The project includes automated git hooks to maintain code quality and enforce development standards. These hooks run automatically during git operations to catch issues early.
+
+#### Available Hooks
+
+- **commit-msg**: Runs when creating commit messages
+  - Validates commit message format using conventional commits
+  - Enforces format: `type(scope): description` (e.g., `feat: add new analytics feature`)
+  - Supported types: `feat`, `fix`, `refactor`, `perf`, `style`, `test`, `docs`, `chore`, `build`, `ci`, `revert`
+
+- **pre-commit**: Runs before each commit
+  - Runs SwiftLint on staged Swift source files under `Sources/`
+  - Skips gracefully if SwiftLint is not installed
+
+- **pre-push**: Runs before each push
+  - Validates branch naming conventions
+  - Builds the project and runs the test suite (Terminal only — GUI clients skip this, CI enforces it)
+  - Prevents pushes if validation or checks fail
+
+#### Enabling Git Hooks
+
+The git hooks are automatically configured the first time you build the project in Xcode. You can also enable them manually:
+
+```bash
+sh scripts/setup-hooks.sh
+```
+
+#### Branch Naming Convention
+
+When creating branches, follow this naming pattern:
+
+```
+<type>/<description>
+
+Examples:
+  feature/sdk-4614-add-session-tracking
+  fix/session-timeout-crash
+  chore/update-dependencies
+```
+
+Allowed types: `feat`, `feature`, `fix`, `hotfix`, `refactor`, `release`, `docs`, `chore`, `test`, `ci`
+
+#### Commit Message Convention
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<optional scope>): <description>
+
+Examples:
+  feat(session): add automatic session timeout
+  fix: resolve crash on app foreground
+  chore(release): v1.3.0
 ```
 
 ---

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -1422,6 +1422,7 @@
 		};
 		5348DB662F617E4000DB7FAC /* Setup Git Hooks */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -1287,6 +1287,7 @@
 			buildConfigurationList = 5351AA6D2C6BE95D003C3C47 /* Build configuration list for PBXNativeTarget "RudderStackAnalytics" */;
 			buildPhases = (
 				5351AA612C6BE95D003C3C47 /* Headers */,
+				5348DB662F617E4000DB7FAC /* Setup Git Hooks */,
 				531744862D5618E000E98C03 /* SwiftLint */,
 				5351AA622C6BE95D003C3C47 /* Sources */,
 				5351AA632C6BE95D003C3C47 /* Frameworks */,
@@ -1418,6 +1419,24 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint --config \"${PROJECT_DIR}/.swiftlint.yml\"\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		5348DB662F617E4000DB7FAC /* Setup Git Hooks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Setup Git Hooks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ -z \"$(git config --local core.hooksPath 2>/dev/null)\" ]; then\n      echo \"Setting up git hooks for the first time...\"\n      sh \"${SRCROOT}/scripts/setup-hooks.sh\"\n  fi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -1437,7 +1437,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$(git config --local core.hooksPath 2>/dev/null)\" ]; then\n      echo \"Setting up git hooks for the first time...\"\n      sh \"${SRCROOT}/scripts/setup-hooks.sh\"\n  fi\n";
+			shellScript = "if ! git -C \"${SRCROOT}\" rev-parse --is-inside-work-tree > /dev/null 2>&1; then\n    echo \"info: Not inside a git repository. Skipping git hooks setup.\"\n    exit 0\nfi\nif [ -z \"$(git config --local core.hooksPath 2>/dev/null)\" ]; then\n    echo \"Setting up git hooks for the first time...\"\n    sh \"${SRCROOT}/scripts/setup-hooks.sh\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# ──────────────────────────────────────────────────────────────
+# commit-msg hook
+# Validates that commit messages follow Conventional Commits format.
+# Runs after the developer types the message, before the commit is saved.
+#
+# Git passes the path to the commit message file as $1.
+# ──────────────────────────────────────────────────────────────
+
+# ──────────────────────────────────────────────────────────────
+# Run global hooks first (Gitleaks, etc.) — DO NOT REMOVE
+# Our local core.hooksPath overrides the global one, so we must
+# manually invoke it to keep Gitleaks and other global hooks alive.
+# ──────────────────────────────────────────────────────────────
+GLOBAL_HOOKS_PATH=$(git config --global --get core.hooksPath 2>/dev/null)
+if [ -n "$GLOBAL_HOOKS_PATH" ] && [ -x "$GLOBAL_HOOKS_PATH/commit-msg" ]; then
+    "$GLOBAL_HOOKS_PATH/commit-msg" "$@" || exit $?
+fi
+
+commit_message_file="$1"
+commit_message=$(cat "$commit_message_file")
+
+# Block empty or whitespace-only messages
+if [[ -z "$commit_message" || "$commit_message" =~ ^[[:space:]]*$ ]]; then
+    echo "Error: Commit message cannot be empty." >&2
+    exit 1
+fi
+
+# Validate format: type(optional-scope): description  OR  Merge ...
+valid_commit_regex="^(feat|fix|refactor|perf|style|test|docs|chore|build|ci|revert)(\(.*\))?!?: .*$|^Merge .*"
+
+if [[ ! $commit_message =~ $valid_commit_regex ]]; then
+    echo ""
+    echo "Error: Invalid commit message format."
+    echo ""
+    echo "  Your message:  $commit_message"
+    echo ""
+    echo "  Expected format: <type>(<optional scope>): <description>"
+    echo "  Allowed types:   feat | fix | refactor | perf | style | test | docs | chore | build | ci | revert"
+    echo ""
+    echo "  Examples:"
+    echo "    feat(session): add automatic session timeout"
+    echo "    fix: resolve crash on app foreground"
+    echo "    chore(release): v1.3.0"
+    echo ""
+    exit 1
+fi

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -19,22 +19,26 @@ if [ -n "$GLOBAL_HOOKS_PATH" ] && [ -x "$GLOBAL_HOOKS_PATH/commit-msg" ]; then
 fi
 
 commit_message_file="$1"
-commit_message=$(cat "$commit_message_file")
+
+# Extract the subject line: first non-empty, non-comment line.
+# This correctly handles multi-line messages (subject + body) and
+# editor template comments (lines starting with #).
+commit_subject=$(grep -v '^#' "$commit_message_file" | grep -v '^[[:space:]]*$' | head -1)
 
 # Block empty or whitespace-only messages
-if [[ -z "$commit_message" || "$commit_message" =~ ^[[:space:]]*$ ]]; then
+if [[ -z "$commit_subject" ]]; then
     echo "Error: Commit message cannot be empty." >&2
     exit 1
 fi
 
 # Validate format: type(optional-scope): description  OR  Merge ...
-valid_commit_regex="^(feat|fix|refactor|perf|style|test|docs|chore|build|ci|revert)(\(.*\))?!?: .*$|^Merge .*"
+valid_commit_regex="^(feat|fix|refactor|perf|style|test|docs|chore|build|ci|revert)(\(.*\))?!?: .+$|^Merge .*"
 
-if [[ ! $commit_message =~ $valid_commit_regex ]]; then
+if [[ ! $commit_subject =~ $valid_commit_regex ]]; then
     echo ""
     echo "Error: Invalid commit message format."
     echo ""
-    echo "  Your message:  $commit_message"
+    echo "  Your message:  $commit_subject"
     echo ""
     echo "  Expected format: <type>(<optional scope>): <description>"
     echo "  Allowed types:   feat | fix | refactor | perf | style | test | docs | chore | build | ci | revert"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -4,8 +4,12 @@
 # pre-commit hook
 # Runs SwiftLint on staged Swift source files before committing.
 #
-# This hook does NOT use `set -e` intentionally — see explanation
-# in the developer guide about why (Gitleaks chaining safety).
+# NOTE: This hook intentionally does NOT use `set -e`.
+# `set -e` would cause the script to exit immediately on any error,
+# potentially before reaching the global hooks chaining block at the
+# top. If that block were skipped, Gitleaks (or any other global hook)
+# would silently stop running. Explicit exit code checks are used
+# instead to ensure the global hooks always execute.
 # ──────────────────────────────────────────────────────────────
 
 # ──────────────────────────────────────────────────────────────
@@ -21,6 +25,8 @@ fi
 echo "Running pre-commit checks..."
 
 # Get list of staged Swift files under Sources/ that are Added, Copied, or Modified
+# Use --name-only (non-null) only for the existence check; actual linting uses -z / xargs -0
+# to safely handle file paths that contain spaces or special characters.
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- 'Sources/**/*.swift')
 
 if [ -n "$STAGED_FILES" ]; then
@@ -28,8 +34,26 @@ if [ -n "$STAGED_FILES" ]; then
     if command -v swiftlint &> /dev/null; then
         echo "[INFO] Running SwiftLint on staged files..."
 
-        # Run SwiftLint in strict mode (warnings are treated as errors)
-        if ! echo "$STAGED_FILES" | xargs swiftlint lint --config .swiftlint.yml --strict; then
+        # Lint the staged index content, not the working tree.
+        # For each staged file, extract the blob from the index via
+        # `git show ":$file"` into a temp file that mirrors the original
+        # directory structure so SwiftLint error output shows readable paths.
+        LINT_FAILED=0
+        TMP_DIR=$(mktemp -d)
+
+        while IFS= read -r file; do
+            tmp_file="$TMP_DIR/$file"
+            mkdir -p "$(dirname "$tmp_file")"
+            git show ":$file" > "$tmp_file"
+
+            if ! swiftlint lint --config .swiftlint.yml --strict "$tmp_file"; then
+                LINT_FAILED=1
+            fi
+        done < <(git diff --cached --name-only --diff-filter=ACM -- 'Sources/**/*.swift')
+
+        rm -rf "$TMP_DIR"
+
+        if [ $LINT_FAILED -ne 0 ]; then
             echo ""
             echo "[ERROR] SwiftLint found issues. Please fix them before committing."
             echo "        Run 'swiftlint lint --config .swiftlint.yml' to see all issues."

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# ──────────────────────────────────────────────────────────────
+# pre-commit hook
+# Runs SwiftLint on staged Swift source files before committing.
+#
+# This hook does NOT use `set -e` intentionally — see explanation
+# in the developer guide about why (Gitleaks chaining safety).
+# ──────────────────────────────────────────────────────────────
+
+# ──────────────────────────────────────────────────────────────
+# Run global hooks first (Gitleaks, etc.) — DO NOT REMOVE
+# Our local core.hooksPath overrides the global one, so we must
+# manually invoke it to keep Gitleaks and other global hooks alive.
+# ──────────────────────────────────────────────────────────────
+GLOBAL_HOOKS_PATH=$(git config --global --get core.hooksPath 2>/dev/null)
+if [ -n "$GLOBAL_HOOKS_PATH" ] && [ -x "$GLOBAL_HOOKS_PATH/pre-commit" ]; then
+    "$GLOBAL_HOOKS_PATH/pre-commit" "$@" || exit $?
+fi
+
+echo "Running pre-commit checks..."
+
+# Get list of staged Swift files under Sources/ that are Added, Copied, or Modified
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- 'Sources/**/*.swift')
+
+if [ -n "$STAGED_FILES" ]; then
+    # Check if SwiftLint is installed on this machine
+    if command -v swiftlint &> /dev/null; then
+        echo "[INFO] Running SwiftLint on staged files..."
+
+        # Run SwiftLint in strict mode (warnings are treated as errors)
+        if ! echo "$STAGED_FILES" | xargs swiftlint lint --config .swiftlint.yml --strict; then
+            echo ""
+            echo "[ERROR] SwiftLint found issues. Please fix them before committing."
+            echo "        Run 'swiftlint lint --config .swiftlint.yml' to see all issues."
+            exit 1
+        fi
+
+        echo "[SUCCESS] SwiftLint checks passed."
+    else
+        echo "[WARNING] SwiftLint is not installed. Skipping lint checks."
+        echo "          Install it with: brew install swiftlint"
+    fi
+else
+    echo "[INFO] No staged Swift source files to lint. Skipping."
+fi

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -24,12 +24,13 @@ fi
 
 echo "Running pre-commit checks..."
 
-# Get list of staged Swift files under Sources/ that are Added, Copied, or Modified
-# Use --name-only (non-null) only for the existence check; actual linting uses -z / xargs -0
-# to safely handle file paths that contain spaces or special characters.
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- 'Sources/**/*.swift')
+# Enumerate staged Swift files once into a temp list (null-delimited).
+# -z produces NUL-separated paths — safe for filenames with spaces, newlines,
+# or special characters. ACMR includes renames so the new path is also linted.
+TMP_LIST=$(mktemp)
+git diff --cached -z --name-only --diff-filter=ACMR -- 'Sources/**/*.swift' > "$TMP_LIST"
 
-if [ -n "$STAGED_FILES" ]; then
+if [ -s "$TMP_LIST" ]; then
     # Check if SwiftLint is installed on this machine
     if command -v swiftlint &> /dev/null; then
         echo "[INFO] Running SwiftLint on staged files..."
@@ -41,7 +42,7 @@ if [ -n "$STAGED_FILES" ]; then
         LINT_FAILED=0
         TMP_DIR=$(mktemp -d)
 
-        while IFS= read -r file; do
+        while IFS= read -r -d '' file; do
             tmp_file="$TMP_DIR/$file"
             mkdir -p "$(dirname "$tmp_file")"
             git show ":$file" > "$tmp_file"
@@ -49,7 +50,8 @@ if [ -n "$STAGED_FILES" ]; then
             if ! swiftlint lint --config .swiftlint.yml --strict "$tmp_file"; then
                 LINT_FAILED=1
             fi
-        done < <(git diff --cached --name-only --diff-filter=ACM -- 'Sources/**/*.swift')
+        done < "$TMP_LIST"
+        rm -f "$TMP_LIST"
 
         rm -rf "$TMP_DIR"
 
@@ -62,9 +64,11 @@ if [ -n "$STAGED_FILES" ]; then
 
         echo "[SUCCESS] SwiftLint checks passed."
     else
+        rm -f "$TMP_LIST"
         echo "[WARNING] SwiftLint is not installed. Skipping lint checks."
         echo "          Install it with: brew install swiftlint"
     fi
 else
+    rm -f "$TMP_LIST"
     echo "[INFO] No staged Swift source files to lint. Skipping."
 fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -27,25 +27,37 @@ echo ""
 
 # ── 1. Validate branch name ──────────────────────────────────
 
-local_branch="$(git rev-parse --abbrev-ref HEAD)"
+# git passes each pushed ref on stdin as:
+#   <local-ref> <local-sha> <remote-ref> <remote-sha>
+# Read all lines upfront so stdin is available for later commands.
 valid_branch_regex="^(feat|fix|hotfix|refactor|release|docs|chore|test|ci|feature)\/[a-zA-Z0-9._-]+$|^(main|develop)$"
 
-if [[ ! $local_branch =~ $valid_branch_regex ]]; then
-    echo "[ERROR] Invalid branch name: '$local_branch'"
-    echo ""
-    echo "  Branch names must follow this format:"
-    echo "    <type>/<description>"
-    echo ""
-    echo "  Allowed types: feat | fix | hotfix | refactor | release | docs | chore | test | ci | feature"
-    echo "  Allowed as-is: main | develop"
-    echo ""
-    echo "  Examples:"
-    echo "    feature/sdk-4614-implement-local-hooks"
-    echo "    fix/session-timeout-crash"
-    echo ""
-    exit 1
-fi
-echo "[SUCCESS] Branch name validation passed: '$local_branch'"
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Skip non-branch refs (tags, delete operations, etc.)
+    if [[ "$local_ref" != refs/heads/* ]]; then
+        continue
+    fi
+
+    branch="${local_ref#refs/heads/}"
+
+    if [[ ! $branch =~ $valid_branch_regex ]]; then
+        echo "[ERROR] Invalid branch name: '$branch'"
+        echo ""
+        echo "  Branch names must follow this format:"
+        echo "    <type>/<description>"
+        echo ""
+        echo "  Allowed types: feat | fix | hotfix | refactor | release | docs | chore | test | ci | feature"
+        echo "  Allowed as-is: main | develop"
+        echo ""
+        echo "  Examples:"
+        echo "    feature/sdk-4614-implement-local-hooks"
+        echo "    fix/session-timeout-crash"
+        echo ""
+        exit 1
+    fi
+
+    echo "[SUCCESS] Branch name validation passed: '$branch'"
+done
 
 # ── 2. Build & test (Terminal only) ──────────────────────────
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# ──────────────────────────────────────────────────────────────
+# pre-push hook
+# Validates branch name, builds the project, and runs tests
+# before allowing a push to the remote.
+#
+# NOTE: Build and test steps are skipped when running from a GUI
+# git client (e.g. SourceTree) due to a macOS Gatekeeper
+# restriction that blocks Swift Package Manager from parsing
+# Package.swift in non-interactive contexts. CI enforces these
+# checks for all pushes regardless.
+# ──────────────────────────────────────────────────────────────
+
+# ──────────────────────────────────────────────────────────────
+# Run global hooks first (Gitleaks, etc.) — DO NOT REMOVE
+# Our local core.hooksPath overrides the global one, so we must
+# manually invoke it to keep Gitleaks and other global hooks alive.
+# ──────────────────────────────────────────────────────────────
+GLOBAL_HOOKS_PATH=$(git config --global --get core.hooksPath 2>/dev/null)
+if [ -n "$GLOBAL_HOOKS_PATH" ] && [ -x "$GLOBAL_HOOKS_PATH/pre-push" ]; then
+    "$GLOBAL_HOOKS_PATH/pre-push" "$@" || exit $?
+fi
+
+echo "Running pre-push checks..."
+echo ""
+
+# ── 1. Validate branch name ──────────────────────────────────
+
+local_branch="$(git rev-parse --abbrev-ref HEAD)"
+valid_branch_regex="^(feat|fix|hotfix|refactor|release|docs|chore|test|ci|feature)\/[a-zA-Z0-9._-]+$|^(main|develop)$"
+
+if [[ ! $local_branch =~ $valid_branch_regex ]]; then
+    echo "[ERROR] Invalid branch name: '$local_branch'"
+    echo ""
+    echo "  Branch names must follow this format:"
+    echo "    <type>/<description>"
+    echo ""
+    echo "  Allowed types: feat | fix | hotfix | refactor | release | docs | chore | test | ci | feature"
+    echo "  Allowed as-is: main | develop"
+    echo ""
+    echo "  Examples:"
+    echo "    feature/sdk-4614-implement-local-hooks"
+    echo "    fix/session-timeout-crash"
+    echo ""
+    exit 1
+fi
+echo "[SUCCESS] Branch name validation passed: '$local_branch'"
+
+# ── 2. Build & test (Terminal only) ──────────────────────────
+
+# [ -t 1 ] checks if stdout is connected to an interactive terminal.
+# GUI git clients (SourceTree, Fork, etc.) are non-interactive, and
+# macOS Gatekeeper blocks Swift Package Manager in that context.
+# CI (GitHub Actions) always runs in a terminal and enforces these checks.
+if [ ! -t 1 ]; then
+    echo "[INFO] Non-interactive context detected (GUI git client)."
+    echo "       Skipping build and test checks — CI will enforce them."
+    echo ""
+    echo "All pre-push checks passed. Ready to push."
+    exit 0
+fi
+
+echo ""
+echo "[INFO] Building project (swift build --build-tests)..."
+if ! swift build --build-tests; then
+    echo ""
+    echo "[ERROR] Build failed. Please fix build errors before pushing."
+    exit 1
+fi
+echo "[SUCCESS] Build passed."
+
+echo ""
+echo "[INFO] Running tests (swift test --skip-build --no-parallel)..."
+if ! swift test --skip-build --no-parallel; then
+    echo ""
+    echo "[ERROR] Tests failed. Please fix failing tests before pushing."
+    exit 1
+fi
+echo "[SUCCESS] All tests passed."
+
+echo ""
+echo "All pre-push checks passed. Ready to push."

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -30,7 +30,7 @@ echo ""
 # git passes each pushed ref on stdin as:
 #   <local-ref> <local-sha> <remote-ref> <remote-sha>
 # Read all lines upfront so stdin is available for later commands.
-valid_branch_regex="^(feat|fix|hotfix|refactor|release|docs|chore|test|ci|feature)\/[a-zA-Z0-9._-]+$|^(main|develop)$"
+valid_branch_regex="^(feat|fix|hotfix|refactor|release|docs|chore|test|ci)\/[a-zA-Z0-9._-]+$|^(main|develop)$"
 
 while read -r local_ref local_sha remote_ref remote_sha; do
     # Skip non-branch refs (tags, delete operations, etc.)
@@ -46,11 +46,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo "  Branch names must follow this format:"
         echo "    <type>/<description>"
         echo ""
-        echo "  Allowed types: feat | fix | hotfix | refactor | release | docs | chore | test | ci | feature"
+        echo "  Allowed types: feat | fix | hotfix | refactor | release | docs | chore | test | ci"
         echo "  Allowed as-is: main | develop"
         echo ""
         echo "  Examples:"
-        echo "    feature/sdk-4614-implement-local-hooks"
+        echo "    feat/sdk-4614-implement-local-hooks"
         echo "    fix/session-timeout-crash"
         echo ""
         exit 1

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -60,12 +60,5 @@ else
     echo "  No global hooks detected. Only local hooks will run."
 fi
 
-# ──────────────────────────────────────────────────────────────
-# Pre-approve Swift Package Manager binaries
-# Running swift build once from Terminal lets macOS Gatekeeper
-# approve the SPM binaries (e.g. rudder-sdk-swift-manifest).
-# Without this, GUI git clients (SourceTree, Fork, etc.) trigger
-# a Gatekeeper "Not Opened" dialog when the pre-push hook builds.
-# ──────────────────────────────────────────────────────────────
 echo ""
 echo "Done. You can verify with: git config --local core.hooksPath"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -10,6 +10,12 @@
 
 HOOK_DIR="scripts/git-hooks"
 
+# Check that we're inside a git repository
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Warning: Not inside a git repository. Skipping git hooks setup."
+    exit 0
+fi
+
 # Check that we're in the repo root
 if [ ! -d "$HOOK_DIR" ]; then
     echo "Error: Could not find '$HOOK_DIR'."
@@ -23,7 +29,10 @@ GLOBAL_HOOKS_PATH=$(git config --global core.hooksPath 2>/dev/null || true)
 # Set the LOCAL core.hooksPath for this repo only.
 # IMPORTANT: This overrides the global core.hooksPath for this repo.
 # Each hook script chains back to the global hooks to keep Gitleaks working.
-git config --local core.hooksPath "$HOOK_DIR"
+if ! git config --local core.hooksPath "$HOOK_DIR"; then
+    echo "Error: Failed to set local core.hooksPath. Check your git configuration."
+    exit 1
+fi
 
 # Make sure all hook scripts are executable
 chmod +x "$HOOK_DIR/commit-msg"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# ──────────────────────────────────────────────────────────────
+# setup-hooks.sh
+# One-time setup to activate the project's local git hooks.
+#
+# Run this after cloning the repo:
+#   sh scripts/setup-hooks.sh
+# ──────────────────────────────────────────────────────────────
+
+HOOK_DIR="scripts/git-hooks"
+
+# Check that we're in the repo root
+if [ ! -d "$HOOK_DIR" ]; then
+    echo "Error: Could not find '$HOOK_DIR'."
+    echo "Please run this script from the repository root directory."
+    exit 1
+fi
+
+# Detect the existing global hooksPath (Gitleaks, etc.)
+GLOBAL_HOOKS_PATH=$(git config --global core.hooksPath 2>/dev/null || true)
+
+# Set the LOCAL core.hooksPath for this repo only.
+# IMPORTANT: This overrides the global core.hooksPath for this repo.
+# Each hook script chains back to the global hooks to keep Gitleaks working.
+git config --local core.hooksPath "$HOOK_DIR"
+
+# Make sure all hook scripts are executable
+chmod +x "$HOOK_DIR/commit-msg"
+chmod +x "$HOOK_DIR/pre-commit"
+chmod +x "$HOOK_DIR/pre-push"
+
+echo ""
+echo "Git hooks installed successfully."
+echo ""
+echo "  Local hooks directory: $HOOK_DIR"
+echo "  Hooks activated:"
+echo "    - commit-msg  : Validates conventional commit message format"
+echo "    - pre-commit  : Runs SwiftLint on staged Swift source files"
+echo "    - pre-push    : Validates branch name, builds, and runs tests"
+echo ""
+
+if [ -n "$GLOBAL_HOOKS_PATH" ]; then
+    echo "  Global hooks detected: $GLOBAL_HOOKS_PATH"
+    echo "  Global hooks (Gitleaks) will be chained automatically."
+    echo ""
+
+    # Verify each global hook exists and is executable
+    MISSING=0
+    for hook in commit-msg pre-commit pre-push; do
+        if [ ! -x "$GLOBAL_HOOKS_PATH/$hook" ]; then
+            echo "  [WARNING] Global hook not found or not executable: $GLOBAL_HOOKS_PATH/$hook"
+            MISSING=1
+        fi
+    done
+    if [ "$MISSING" -eq 0 ]; then
+        echo "  All global hooks verified."
+    fi
+else
+    echo "  No global hooks detected. Only local hooks will run."
+fi
+
+# ──────────────────────────────────────────────────────────────
+# Pre-approve Swift Package Manager binaries
+# Running swift build once from Terminal lets macOS Gatekeeper
+# approve the SPM binaries (e.g. rudder-sdk-swift-manifest).
+# Without this, GUI git clients (SourceTree, Fork, etc.) trigger
+# a Gatekeeper "Not Opened" dialog when the pre-push hook builds.
+# ──────────────────────────────────────────────────────────────
+echo ""
+echo "Done. You can verify with: git config --local core.hooksPath"


### PR DESCRIPTION
## Description

This PR introduces local git hooks for the RudderStack Swift SDK to enforce code quality and development standards automatically during git operations. The hooks validate commit message format, run SwiftLint on staged Swift files before committing, and validate branch names plus build and test the project before pushing. The hooks are automatically activated the first time the project is built in Xcode via a new Run Script build phase, requiring no manual setup from contributors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- `scripts/git-hooks/commit-msg` — validates commit messages against the Conventional Commits format (`type(scope): description`) using a regex; blocks empty messages and invalid formats with structured error output; runs global hooks (Gitleaks) first via dynamic `core.hooksPath` lookup
- `scripts/git-hooks/pre-commit` — runs SwiftLint in `--strict` mode on staged Swift files under `Sources/` only; skips gracefully with a warning if SwiftLint is not installed; runs global hooks first
- `scripts/git-hooks/pre-push` — validates branch name against allowed `type/description` format; builds the project with `swift build --build-tests` and runs `swift test --skip-build --no-parallel`; skips build/test in non-interactive (GUI) contexts due to macOS Gatekeeper restrictions — CI enforces these checks; runs global hooks first
- `scripts/setup-hooks.sh` — one-time setup script that sets the local `core.hooksPath`, makes hooks executable, and verifies global hooks (Gitleaks) are chained correctly
- `RudderStackAnalytics.xcodeproj` — added a "Setup Git Hooks" Run Script build phase that automatically runs `setup-hooks.sh` on first Xcode build when `core.hooksPath` is not yet configured
- `README.md` — added a Development section documenting git hooks, setup instructions, branch naming convention, and commit message convention

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

1. Clone the repo fresh and open `RudderStackAnalytics.xcodeproj` in Xcode
2. Build the project (`Cmd+B`) — verify the "Setting up git hooks for the first time..." message appears in the build log
3. Verify hooks are active: `git config --local core.hooksPath` should print `scripts/git-hooks`
4. Test `commit-msg`: run `git commit --allow-empty -m "bad message"` — should be rejected; run `git commit --allow-empty -m "feat: valid message"` — should succeed
5. Test `pre-commit`: stage a Swift file under `Sources/` and commit — should see SwiftLint output; stage a non-Swift file — should skip lint
6. Test `pre-push` from Terminal: run `git push --dry-run origin <branch>` — should validate branch name, build, and run tests
7. Test `pre-push` from SourceTree: push via GUI — should validate branch name only and skip build/test with an info message

## Breaking Changes

No breaking changes. The hooks are opt-in via setup and do not affect SDK consumers integrating via Swift Package Manager.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

No UI changes in this PR.

## Hook Runtime Estimates

| Hook | Estimated Runtime |
|------|------------------|
| `commit-msg` | < 1s |
| `pre-commit` | <2s |
| `pre-push` | 45s–1 min (based on test case runs) |

## Additional Context

The global hooks chaining pattern (`GLOBAL_HOOKS_PATH=$(git config --global --get core.hooksPath)`) ensures Gitleaks and any other global hooks continue to work after the local `core.hooksPath` override. This was the primary design constraint — setting a local `core.hooksPath` would otherwise silently disable the team's global Gitleaks scanner. All three hooks run global hooks first, then local checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Development section to the README covering Git hooks, branch naming, and commit message conventions (note: the section was added twice, causing duplication).

* **Chores**
  * Added an automated Git hook flow: commit-message validation, pre-commit linting of staged Swift files, pre-push branch-name checks with optional build/tests, a one‑time setup to activate local hooks, and a build-phase to trigger setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->