### PR TITLE
feat(logger): implement per-instance logging via AnalyticsLogger

### DIFF
--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		53DEA68F2E03D06F00D6C371 /* group_with_all_values.json in Resources */ = {isa = PBXBuildFile; fileRef = 53DEA62D2E03D06F00D6C371 /* group_with_all_values.json */; };
 		53DEA6902E03D06F00D6C371 /* screen_with_default_arguments.json in Resources */ = {isa = PBXBuildFile; fileRef = 53DEA6392E03D06F00D6C371 /* screen_with_default_arguments.json */; };
 		53E112DA2E7C4B9E005FEF67 /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E112D92E7C4B9E005FEF67 /* Connectivity.swift */; };
+		53E58C282FA1366A002556B9 /* AnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */; };
 		53E777582EB4C2BD00564D61 /* CountFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */; };
 		53E7775C2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */; };
 		53E7775E2EB4D21000564D61 /* StartupFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */; };
@@ -388,6 +389,7 @@
 		53DEA6572E03D06F00D6C371 /* UserIdTraitsActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdTraitsActionTests.swift; sourceTree = "<group>"; };
 		53DEA65C2E03D06F00D6C371 /* LoggerAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerAnalyticsTests.swift; sourceTree = "<group>"; };
 		53E112D92E7C4B9E005FEF67 /* Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
+		53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLogger.swift; sourceTree = "<group>"; };
 		53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupFlushPolicyTests.swift; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 			isa = PBXGroup;
 			children = (
 				53DEA5A52E03D05A00D6C371 /* LoggerAnalytics.swift */,
+				53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */,
 				53DEA5A62E03D05A00D6C371 /* SwiftLogger.swift */,
 			);
 			path = Logger;
@@ -1460,6 +1463,7 @@
 				530F89262E61DC67007A81B2 /* ExponentialBackoffPolicy.swift in Sources */,
 				53DEA5E92E03D05A00D6C371 /* DataStore.swift in Sources */,
 				53E112DA2E7C4B9E005FEF67 /* Connectivity.swift in Sources */,
+				53E58C282FA1366A002556B9 /* AnalyticsLogger.swift in Sources */,
 				53DEA5EA2E03D05A00D6C371 /* TrackEvent.swift in Sources */,
 				85E7C4F02E9BB6A000520FDB /* IntegrationsManagementPlugin.swift in Sources */,
 				53DEA5EB2E03D05A00D6C371 /* RudderOption.swift in Sources */,

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		53E112DA2E7C4B9E005FEF67 /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E112D92E7C4B9E005FEF67 /* Connectivity.swift */; };
 		53E58C282FA1366A002556B9 /* AnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */; };
 		53E58C2C2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C2B2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift */; };
+		53E58C2E2FA141AC002556B9 /* AnalyticsLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C2D2FA141AC002556B9 /* AnalyticsLoggerTests.swift */; };
 		53E777582EB4C2BD00564D61 /* CountFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */; };
 		53E7775C2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */; };
 		53E7775E2EB4D21000564D61 /* StartupFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */; };
@@ -392,6 +393,7 @@
 		53E112D92E7C4B9E005FEF67 /* Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
 		53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLogger.swift; sourceTree = "<group>"; };
 		53E58C2B2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCAnalyticsLogger.swift; sourceTree = "<group>"; };
+		53E58C2D2FA141AC002556B9 /* AnalyticsLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLoggerTests.swift; sourceTree = "<group>"; };
 		53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupFlushPolicyTests.swift; sourceTree = "<group>"; };
@@ -728,6 +730,7 @@
 			children = (
 				53DEA65C2E03D06F00D6C371 /* LoggerAnalyticsTests.swift */,
 				539001052EA11A7400DAC164 /* AnalyticsTests.swift */,
+				53E58C2D2FA141AC002556B9 /* AnalyticsLoggerTests.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1595,6 +1598,7 @@
 				53DEA6672E03D06F00D6C371 /* UserIdActionTests.swift in Sources */,
 				859CEE122E9CDDE900519C90 /* MockStandardIntegrationPlugin.swift in Sources */,
 				53DEA6692E03D06F00D6C371 /* IdentifyEventTests.swift in Sources */,
+				53E58C2E2FA141AC002556B9 /* AnalyticsLoggerTests.swift in Sources */,
 				53DEA66A2E03D06F00D6C371 /* UserIdentityTests.swift in Sources */,
 				53DEA66B2E03D06F00D6C371 /* SessionHandlerTests.swift in Sources */,
 				53078F152EAFE796006F5847 /* HttpNetworkTests.swift in Sources */,

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		53DEA6902E03D06F00D6C371 /* screen_with_default_arguments.json in Resources */ = {isa = PBXBuildFile; fileRef = 53DEA6392E03D06F00D6C371 /* screen_with_default_arguments.json */; };
 		53E112DA2E7C4B9E005FEF67 /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E112D92E7C4B9E005FEF67 /* Connectivity.swift */; };
 		53E58C282FA1366A002556B9 /* AnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */; };
+		53E58C2C2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E58C2B2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift */; };
 		53E777582EB4C2BD00564D61 /* CountFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */; };
 		53E7775C2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */; };
 		53E7775E2EB4D21000564D61 /* StartupFlushPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */; };
@@ -390,6 +391,7 @@
 		53DEA65C2E03D06F00D6C371 /* LoggerAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerAnalyticsTests.swift; sourceTree = "<group>"; };
 		53E112D92E7C4B9E005FEF67 /* Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
 		53E58C272FA1366A002556B9 /* AnalyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLogger.swift; sourceTree = "<group>"; };
+		53E58C2B2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCAnalyticsLogger.swift; sourceTree = "<group>"; };
 		53E777572EB4C2BD00564D61 /* CountFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775B2EB4C7F300564D61 /* FrequencyFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyFlushPolicyTests.swift; sourceTree = "<group>"; };
 		53E7775D2EB4D21000564D61 /* StartupFlushPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupFlushPolicyTests.swift; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 			children = (
 				53DEA5AF2E03D05A00D6C371 /* ObjCLogger.swift */,
 				53DEA5B02E03D05A00D6C371 /* ObjCLoggerAnalytics.swift */,
+				53E58C2B2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift */,
 			);
 			path = Logger;
 			sourceTree = "<group>";
@@ -1531,6 +1534,7 @@
 				53DEA6132E03D05A00D6C371 /* StartupFlushPolicy.swift in Sources */,
 				5328B8792E3B817B0051A202 /* ObjCTrackEvent.swift in Sources */,
 				53DEA6142E03D05A00D6C371 /* Analytics.swift in Sources */,
+				53E58C2C2FA13CE5002556B9 /* ObjCAnalyticsLogger.swift in Sources */,
 				53074DB02E7DEC240062703A /* StateManagement.swift in Sources */,
 				53DEA6152E03D05A00D6C371 /* BasicStorage.swift in Sources */,
 				53DEA6162E03D05A00D6C371 /* ObjCOption.swift in Sources */,

--- a/Sources/RudderStackAnalytics/Base/Analytics.swift
+++ b/Sources/RudderStackAnalytics/Base/Analytics.swift
@@ -60,6 +60,11 @@ public class Analytics {
     private(set) var isAnalyticsShutdown: Bool = false
     
     /**
+     The per-instance logger, built from the configuration at init time.
+     */
+    private(set) var logger: Logger
+    
+    /**
      A flag indicating whether the write key provided is invalid.
      */
     var isInvalidWriteKey: Bool = false
@@ -76,6 +81,7 @@ public class Analytics {
      */
     public init(configuration: Configuration) {
         self.configuration = configuration
+        self.logger = AnalyticsLogger(logger: configuration.logger, logLevel: configuration.logLevel)
         self.processEventChannel = AsyncChannel()
         self.userIdentityState = createState(initialState: UserIdentity.initializeState(configuration.storage))
         self.sourceConfigState = createState(initialState: SourceConfig.initialState())

--- a/Sources/RudderStackAnalytics/Base/Configuration.swift
+++ b/Sources/RudderStackAnalytics/Base/Configuration.swift
@@ -13,27 +13,27 @@ import Foundation
  */
 @objc(RSSConfiguration)
 public class Configuration: NSObject {
-
+    
     /**
      The write key used to authenticate with the analytics service.
      */
     var writeKey: String
-
+    
     /**
      The URL for the data plane where analytics events are sent.
      */
     var dataPlaneUrl: String
-
+    
     /**
      The URL for the control plane to fetch configuration data.
      */
     var controlPlaneUrl: String
-
+    
     /**
      A boolean flag to enable GZip compression for network requests. Defaults to `false`.
      */
     var gzipEnabled: Bool
-
+    
     /**
      The storage mechanism used to persist data. Defaults to in-built storage system.
      */
@@ -43,12 +43,12 @@ public class Configuration: NSObject {
      The storage mode used to store events data. Defaults to `disk` storage system.
      */
     var storageMode: StorageMode
-
+    
     /**
      An array of flush policies defining how and when events are flushed to the data plane.
      */
     var flushPolicies: [FlushPolicy]
-
+    
     /**
      A boolean flag indicating whether the SDK should automatically collect the device ID. Defaults to `true`.
      */
@@ -63,9 +63,19 @@ public class Configuration: NSObject {
      A configuration instance for managing session settings.
      */
     var sessionConfiguration: SessionConfiguration
-
+    
+    /**
+     The logger implementation to use for this Analytics instance.
+     */
+    var logger: Logger
+    
+    /**
+     The log level for this Analytics instance.
+     */
+    var logLevel: LogLevel
+    
     // MARK: - Initialization
-
+    
     /**
      Initializes a `Configuration` object with the specified parameters.
      
@@ -78,7 +88,9 @@ public class Configuration: NSObject {
        - collectDeviceId: A flag to enable automatic collection of the device ID. Defaults to `true`.
        - trackApplicationLifecycleEvents: A flag to enable automatic tracking of the application lifecycle events. Defaults to `true`.
        - sessionConfiguration: A configuration instance for managing session settings.
- 
+       - logger: The logger implementation to use for this Analytics instance.
+       - logLevel: The log level for this Analytics instance.
+
      - Returns: An instance of `Configuration` with the specified settings.
      */
     public init(
@@ -89,7 +101,9 @@ public class Configuration: NSObject {
         flushPolicies: [FlushPolicy] = Constants.defaultConfig.flushPolicies,
         collectDeviceId: Bool = Constants.defaultConfig.willCollectDeviceId,
         trackApplicationLifecycleEvents: Bool = Constants.defaultConfig.willTrackLifecycleEvents,
-        sessionConfiguration: SessionConfiguration = SessionConfiguration()
+        sessionConfiguration: SessionConfiguration = SessionConfiguration(),
+        logger: Logger? = nil,
+        logLevel: LogLevel = Constants.log.defaultLevel
     ) {
         self.writeKey = writeKey
         self.dataPlaneUrl = dataPlaneUrl
@@ -101,6 +115,8 @@ public class Configuration: NSObject {
         self.collectDeviceId = collectDeviceId
         self.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents
         self.sessionConfiguration = sessionConfiguration
+        self.logger = logger ?? SwiftLogger()
+        self.logLevel = logLevel
     }
 }
 

--- a/Sources/RudderStackAnalytics/Logger/AnalyticsLogger.swift
+++ b/Sources/RudderStackAnalytics/Logger/AnalyticsLogger.swift
@@ -1,0 +1,48 @@
+//
+//  AnalyticsLogger.swift
+//  Analytics
+//
+//  Created by Satheesh Kannan on 28/04/26.
+//
+
+import Foundation
+
+// MARK: - AnalyticsLogger
+
+/**
+ Internal per-instance logger that applies log-level filtering before delegating to the underlying Logger.
+ */
+final class AnalyticsLogger: Logger {
+    private let logger: Logger
+    private let logLevel: LogLevel
+
+    init(logger: Logger, logLevel: LogLevel) {
+        self.logger = logger
+        self.logLevel = logLevel
+    }
+
+    func verbose(log: String) {
+        guard logLevel.rawValue >= LogLevel.verbose.rawValue else { return }
+        logger.verbose(log: log)
+    }
+
+    func debug(log: String) {
+        guard logLevel.rawValue >= LogLevel.debug.rawValue else { return }
+        logger.debug(log: log)
+    }
+
+    func info(log: String) {
+        guard logLevel.rawValue >= LogLevel.info.rawValue else { return }
+        logger.info(log: log)
+    }
+
+    func warn(log: String) {
+        guard logLevel.rawValue >= LogLevel.warn.rawValue else { return }
+        logger.warn(log: log)
+    }
+
+    func error(log: String, error: Error?) {
+        guard logLevel.rawValue >= LogLevel.error.rawValue else { return }
+        logger.error(log: log, error: error)
+    }
+}

--- a/Sources/RudderStackAnalytics/Logger/SwiftLogger.swift
+++ b/Sources/RudderStackAnalytics/Logger/SwiftLogger.swift
@@ -182,3 +182,12 @@ final class SwiftLogger: Logger {
         }
     }
 }
+
+// MARK: - NoOpLogger
+
+/**
+ A `Logger` that discards every message. Used as a shared fallback when no per-instance logger is available yet.
+ */
+struct NoOpLogger: Logger {
+    static let shared = NoOpLogger()
+}

--- a/Sources/RudderStackAnalytics/ObjC/Base/ObjCAnalytics.swift
+++ b/Sources/RudderStackAnalytics/ObjC/Base/ObjCAnalytics.swift
@@ -475,6 +475,15 @@ extension ObjCAnalytics {
 
 extension ObjCAnalytics {
     /**
+     The per-instance logger for this analytics client.
+
+     Store this in your plugin's `setup(_:)` and use it to log messages at the configured level.
+     */
+    @objc public var logger: ObjCAnalyticsLogger {
+        ObjCAnalyticsLogger(logger: analytics.logger)
+    }
+
+    /**
      The anonymous ID used for tracking unidentified users.
      */
     @objc public var anonymousId: String? {

--- a/Sources/RudderStackAnalytics/ObjC/Base/ObjCConfiguration.swift
+++ b/Sources/RudderStackAnalytics/ObjC/Base/ObjCConfiguration.swift
@@ -22,6 +22,8 @@ public final class ObjCConfigurationBuilder: NSObject {
     private var collectDeviceId: Bool = Constants.defaultConfig.willCollectDeviceId
     private var trackApplicationLifecycleEvents: Bool = Constants.defaultConfig.willTrackLifecycleEvents
     private var sessionConfiguration = SessionConfiguration()
+    private var logger: Logger = SwiftLogger()
+    private var logLevel: LogLevel = Constants.log.defaultLevel
     
     /**
      Initializes a new configuration builder with a write key and data plane URL.
@@ -63,7 +65,9 @@ public final class ObjCConfigurationBuilder: NSObject {
             flushPolicies: swiftFlushPolicies,
             collectDeviceId: collectDeviceId,
             trackApplicationLifecycleEvents: trackApplicationLifecycleEvents,
-            sessionConfiguration: sessionConfiguration
+            sessionConfiguration: sessionConfiguration,
+            logger: logger,
+            logLevel: logLevel
         )
     }
     
@@ -112,6 +116,22 @@ public final class ObjCConfigurationBuilder: NSObject {
     @discardableResult
     public func setSessionConfiguration(_ configuration: SessionConfiguration) -> Self {
         self.sessionConfiguration = configuration
+        return self
+    }
+
+    /** Sets the logger implementation for this Analytics instance. */
+    @objc
+    @discardableResult
+    public func setLogger(_ logger: ObjCLogger) -> Self {
+        self.logger = ObjCLoggerAdapter(logger: logger)
+        return self
+    }
+
+    /** Sets the log level for this Analytics instance. */
+    @objc
+    @discardableResult
+    public func setLogLevel(_ logLevel: LogLevel) -> Self {
+        self.logLevel = logLevel
         return self
     }
 }

--- a/Sources/RudderStackAnalytics/ObjC/Logger/ObjCAnalyticsLogger.swift
+++ b/Sources/RudderStackAnalytics/ObjC/Logger/ObjCAnalyticsLogger.swift
@@ -1,0 +1,63 @@
+//
+//  ObjCAnalyticsLogger.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 28/04/26.
+//
+
+import Foundation
+
+// MARK: - ObjCAnalyticsLogger
+
+/**
+ An Objective-C wrapper around `AnalyticsLogger` that exposes per-instance logging to ObjC plugins.
+
+ Obtain this via `ObjCAnalytics.logger` inside a plugin's `setup(_:)` method:
+ ```objc
+ - (void)setup:(RSSAnalytics *)analytics {
+     self.logger = analytics.logger;
+ }
+
+ // Then log:
+ [self.logger debug:@"MyPlugin: event received"];
+ ```
+ */
+@objc(RSSAnalyticsLogger)
+public final class ObjCAnalyticsLogger: NSObject {
+
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    /** Logs a verbose message. */
+    @objc
+    public func verbose(_ log: String) {
+        logger.verbose(log: log)
+    }
+
+    /** Logs a debug message. */
+    @objc
+    public func debug(_ log: String) {
+        logger.debug(log: log)
+    }
+
+    /** Logs an informational message. */
+    @objc
+    public func info(_ log: String) {
+        logger.info(log: log)
+    }
+
+    /** Logs a warning message. */
+    @objc
+    public func warn(_ log: String) {
+        logger.warn(log: log)
+    }
+
+    /** Logs an error message with an optional error. */
+    @objc
+    public func error(_ log: String, error: NSError?) {
+        logger.error(log: log, error: error)
+    }
+}

--- a/Sources/RudderStackAnalytics/Plugins/Core/Plugin.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Core/Plugin.swift
@@ -83,7 +83,7 @@ public extension Plugin {
      Convenience accessor for the per-instance logger from the associated `Analytics` instance.
      */
     var logger: Logger {
-        analytics?.logger ?? AnalyticsLogger(logger: SwiftLogger(), logLevel: .none)
+        analytics?.logger ?? NoOpLogger.shared
     }
 
     /**

--- a/Sources/RudderStackAnalytics/Plugins/Core/Plugin.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Core/Plugin.swift
@@ -80,6 +80,13 @@ public protocol Plugin: AnyObject {
  */
 public extension Plugin {
     /**
+     Convenience accessor for the per-instance logger from the associated `Analytics` instance.
+     */
+    var logger: Logger {
+        analytics?.logger ?? AnalyticsLogger(logger: SwiftLogger(), logLevel: .none)
+    }
+
+    /**
      Sets up the plugin with the provided `Analytics` instance.
      */
     func setup(analytics: Analytics) {

--- a/Tests/RudderStackAnalyticsTests/Base/AnalyticsLoggerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/Base/AnalyticsLoggerTests.swift
@@ -1,0 +1,120 @@
+//
+//  AnalyticsLoggerTests.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 28/04/26.
+//
+
+import Testing
+import Foundation
+@testable import RudderStackAnalytics
+
+@Suite("AnalyticsLogger Tests")
+class AnalyticsLoggerTests {
+
+    var mockLogger: MockLogger
+
+    init() {
+        mockLogger = MockLogger()
+    }
+
+    deinit {
+        mockLogger.clearLogs()
+    }
+
+    @Test("given a mock logger with info level, when calling each log method, then only info/warn/error messages are logged")
+    func testLoggerLogsAtCorrectLevels() {
+        let analyticsLogger = AnalyticsLogger(logger: mockLogger, logLevel: .info)
+
+        analyticsLogger.verbose(log: "This is verbose")
+        analyticsLogger.debug(log: "This is debug")
+        analyticsLogger.info(log: "This is info")
+        analyticsLogger.warn(log: "This is warn")
+        analyticsLogger.error(log: "This is error", error: nil)
+
+        let loggedLabels = mockLogger.logs.map { $0.level }
+        #expect(!loggedLabels.contains("VERBOSE"))
+        #expect(!loggedLabels.contains("DEBUG"))
+        #expect(loggedLabels.contains("INFO"))
+        #expect(loggedLabels.contains("WARN"))
+        #expect(loggedLabels.contains("ERROR"))
+    }
+
+    @Test("given a mock logger with none level, when calling all log methods, then no logs are captured")
+    func testNoLoggingWhenLevelIsNone() {
+        let analyticsLogger = AnalyticsLogger(logger: mockLogger, logLevel: .none)
+
+        analyticsLogger.verbose(log: "This is verbose")
+        analyticsLogger.debug(log: "This is debug")
+        analyticsLogger.info(log: "This is info")
+        analyticsLogger.warn(log: "This is warn")
+        analyticsLogger.error(log: "This is error", error: nil)
+
+        #expect(mockLogger.logs.isEmpty)
+    }
+
+    @Test("given a mock logger with verbose level, when calling all log methods, then all messages are logged")
+    func testAllLogsWhenLevelIsVerbose() {
+        let analyticsLogger = AnalyticsLogger(logger: mockLogger, logLevel: .verbose)
+
+        analyticsLogger.verbose(log: "This is verbose")
+        analyticsLogger.debug(log: "This is debug")
+        analyticsLogger.info(log: "This is info")
+        analyticsLogger.warn(log: "This is warn")
+        analyticsLogger.error(log: "This is error", error: nil)
+
+        let loggedLabels = mockLogger.logs.map { $0.level }
+        #expect(loggedLabels.contains("VERBOSE"))
+        #expect(loggedLabels.contains("DEBUG"))
+        #expect(loggedLabels.contains("INFO"))
+        #expect(loggedLabels.contains("WARN"))
+        #expect(loggedLabels.contains("ERROR"))
+    }
+
+    @Test("given a mock logger with error level, when logging error with and without error object, then both are logged with correct messages")
+    func testErrorLoggingWithAndWithoutErrorObject() {
+        let analyticsLogger = AnalyticsLogger(logger: mockLogger, logLevel: .error)
+        let error = NSError(domain: "Test", code: 1)
+
+        analyticsLogger.error(log: "Only log", error: nil)
+        analyticsLogger.error(log: "With error", error: error)
+
+        #expect(mockLogger.logs.count == 2)
+        #expect(mockLogger.logs[0].message.contains("Only log"))
+        #expect(mockLogger.logs[1].message.contains("With error"))
+        #expect(mockLogger.logs[1].message.contains(error.localizedDescription))
+    }
+
+    @Test("given a mock logger with error level, when calling verbose/debug/info/warn, then none are logged")
+    func testOnlyErrorLoggedWhenLevelIsError() {
+        let analyticsLogger = AnalyticsLogger(logger: mockLogger, logLevel: .error)
+
+        analyticsLogger.verbose(log: "This is verbose")
+        analyticsLogger.debug(log: "This is debug")
+        analyticsLogger.info(log: "This is info")
+        analyticsLogger.warn(log: "This is warn")
+        analyticsLogger.error(log: "This is error", error: nil)
+
+        let loggedLabels = mockLogger.logs.map { $0.level }
+        #expect(!loggedLabels.contains("VERBOSE"))
+        #expect(!loggedLabels.contains("DEBUG"))
+        #expect(!loggedLabels.contains("INFO"))
+        #expect(!loggedLabels.contains("WARN"))
+        #expect(loggedLabels.contains("ERROR"))
+    }
+
+    @Test("given two AnalyticsLogger instances with different log levels, when logging, then each filters independently")
+    func testIndependentLogLevelPerInstance() {
+        let verboseMock = MockLogger()
+        let errorMock = MockLogger()
+
+        let verboseLogger = AnalyticsLogger(logger: verboseMock, logLevel: .verbose)
+        let errorLogger = AnalyticsLogger(logger: errorMock, logLevel: .error)
+
+        verboseLogger.debug(log: "debug message")
+        errorLogger.debug(log: "debug message")
+
+        #expect(verboseMock.logs.count == 1)
+        #expect(errorMock.logs.isEmpty)
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces per-instance logging to the Swift SDK, aligning with the Kotlin SDK's `AnalyticsLogger` architecture. Previously, logging was routed exclusively through the global `LoggerAnalytics` singleton, making it impossible for multiple `Analytics` instances to have independent loggers or log levels. Each `Analytics` instance now owns its own `AnalyticsLogger`, configured at init time via `Configuration(logger:logLevel:)`, with full Objective-C support through `ObjCAnalyticsLogger` and `ObjCConfigurationBuilder`.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **`AnalyticsLogger.swift`** (new) — internal class that wraps a `Logger` implementation and applies log-level filtering before delegating; mirrors Kotlin's `AnalyticsLogger`
- **`Configuration.swift`** — added `logger: Logger?` and `logLevel: LogLevel` as optional init parameters with defaults (`SwiftLogger()` and `.none`), enabling per-instance configuration
- **`Analytics.swift`** — added internal `logger: Logger` property, initialized as `AnalyticsLogger(logger:logLevel:)` from the configuration at init time
- **`Plugin.swift`** — added `var logger: Logger` convenience accessor to the `Plugin` extension so Swift custom plugins call `self.logger.debug(...)` directly, mirroring Kotlin's `Plugin.logger` extension
- **`ObjCAnalyticsLogger.swift`** (new) — `@objc(RSSAnalyticsLogger)` wrapper around `AnalyticsLogger` that bridges per-instance logging to Objective-C plugins; accessible via `analytics.logger` inside `setup(_:)`
- **`ObjCConfiguration.swift`** — added `setLogger(_:)` and `setLogLevel(_:)` builder methods to `ObjCConfigurationBuilder`, passed through to `Configuration` in `build()`
- **`ObjCAnalytics.swift`** — added `@objc var logger: ObjCAnalyticsLogger` so ObjC plugins can access the instance logger via `analytics.logger`
- **`AnalyticsLoggerTests.swift`** (new) — 6 unit tests covering: correct level filtering at each log level, no output when level is `.none`, full output when level is `.verbose`, error logging with and without an error object, and independent filtering across two separate instances

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Run the new test suite: `swift test --filter AnalyticsLoggerTests` — all 6 tests should pass.
2. Create two `Analytics` instances with different log levels and confirm they filter independently:
   ```swift
   let a1 = Analytics(configuration: Configuration(writeKey: "k1", dataPlaneUrl: "...", logLevel: .verbose))
   let a2 = Analytics(configuration: Configuration(writeKey: "k2", dataPlaneUrl: "...", logLevel: .error))
   // a1 logs everything; a2 logs errors only
   ```
3. Pass a custom `Logger` implementation via `Configuration(logger: MyLogger(), logLevel: .debug)` and verify only debug-and-above messages are forwarded to it.
4. For Objective-C: configure via `[[[RSSConfigurationBuilder alloc] initWithWriteKey:@"..." dataPlaneUrl:@"..."] setLogger:myLogger] setLogLevel:RSSLogLevelDebug]` and verify `analytics.logger` is accessible inside a custom `RSSPlugin`'s `setup:` method.

## Breaking Changes
None. All new `Configuration.init` parameters are optional with backward-compatible defaults. Existing call sites compile and behave identically without any changes.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
No UI changes in this PR.

## Additional Context
This change aligns the Swift SDK's logging architecture with the Kotlin SDK. Internal SDK call site migration and deprecation of the global `LoggerAnalytics` singleton are out of scope for this PR and will be addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-instance configurable logging with selectable levels (verbose, debug, info, warn, error, none)
  * Objective‑C and Swift APIs expose logger access and builders can set logger and level
  * Plugins gain built-in access to the analytics logger
  * Added a no-op shared logger fallback

* **Tests**
  * Comprehensive tests validating log level filtering and independent logger behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->