### PR TITLE
feat(session): add option to skip session activity updates for background events

### DIFF
--- a/Sources/RudderStackAnalytics/Base/Configuration.swift
+++ b/Sources/RudderStackAnalytics/Base/Configuration.swift
@@ -119,16 +119,23 @@ public class SessionConfiguration: NSObject {
      The timeout duration for a session, in milliseconds.
      */
     var sessionTimeoutInMillis: UInt64
-    
+
+    /**
+     When `true`, background events update the session's last activity timestamp, extending the session timeout. Defaults to `false`. Only applicable when automatic session tracking is enabled.
+     */
+    public let updateSessionOnBackgroundEvents: Bool
+
     /**
      Initializes a new session configuration instance.
-     
+
      - Parameters:
         - automaticSessionTracking: A boolean indicating whether session tracking should be automatic. Default is `true`.
         - sessionTimeoutInMillis: The session timeout duration in milliseconds. Default is `300_000` (5 minutes).
+        - updateSessionOnBackgroundEvents: When `true`, background events update the session's last activity timestamp, extending the session timeout. Defaults to `false`. Only applicable when automatic session tracking is enabled.
      */
-    public init(automaticSessionTracking: Bool = Constants.defaultConfig.automaticSessionTrackingStatus, sessionTimeoutInMillis: UInt64 = Constants.defaultConfig.sessionTimeoutInMillis) {
+    public init(automaticSessionTracking: Bool = Constants.defaultConfig.automaticSessionTrackingStatus, sessionTimeoutInMillis: UInt64 = Constants.defaultConfig.sessionTimeoutInMillis, updateSessionOnBackgroundEvents: Bool = Constants.defaultConfig.updateSessionOnBackgroundEvents) {
         self.automaticSessionTracking = automaticSessionTracking
         self.sessionTimeoutInMillis = sessionTimeoutInMillis
+        self.updateSessionOnBackgroundEvents = updateSessionOnBackgroundEvents
     }
 }

--- a/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
@@ -221,5 +221,5 @@ public struct _DefaultConfig {
  **Important:**
  Do not edit this value unless performing a manual release.
  */
-let RSVersion: String = "1.2.1"
+let RSVersion: String = "1.3.0-beta.1"
 let RSLibraryName: String = "rudder-sdk-swift"

--- a/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
@@ -196,6 +196,9 @@ public struct _DefaultConfig {
     /// Default session timeout duration in milliseconds (5 minutes).
     public let sessionTimeoutInMillis: UInt64 = 300_000
 
+    /// Whether to update the session on background events by default.
+    public let updateSessionOnBackgroundEvents: Bool = false
+
     /// Default storage mode used for persisting data.
     let storageMode: StorageMode = .disk
     

--- a/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/Constants.swift
@@ -221,5 +221,5 @@ public struct _DefaultConfig {
  **Important:**
  Do not edit this value unless performing a manual release.
  */
-let RSVersion: String = "1.3.0-beta.1"
+let RSVersion: String = "1.2.1"
 let RSLibraryName: String = "rudder-sdk-swift"

--- a/Sources/RudderStackAnalytics/ObjC/Base/ObjCSessionConfiguration.swift
+++ b/Sources/RudderStackAnalytics/ObjC/Base/ObjCSessionConfiguration.swift
@@ -16,6 +16,7 @@ public final class ObjCSessionConfigurationBuilder: NSObject {
 
     private var automaticSessionTracking: Bool = Constants.defaultConfig.automaticSessionTrackingStatus
     private var sessionTimeoutInMillis: UInt64 = Constants.defaultConfig.sessionTimeoutInMillis
+    private var updateSessionOnBackgroundEvents: Bool = Constants.defaultConfig.updateSessionOnBackgroundEvents
 
     /**
      Initializes a new builder.
@@ -30,7 +31,7 @@ public final class ObjCSessionConfigurationBuilder: NSObject {
      */
     @objc
     public func build() -> SessionConfiguration {
-        return SessionConfiguration(automaticSessionTracking: automaticSessionTracking, sessionTimeoutInMillis: sessionTimeoutInMillis)
+        return SessionConfiguration(automaticSessionTracking: automaticSessionTracking, sessionTimeoutInMillis: sessionTimeoutInMillis, updateSessionOnBackgroundEvents: updateSessionOnBackgroundEvents)
     }
 
     /**
@@ -58,6 +59,19 @@ public final class ObjCSessionConfigurationBuilder: NSObject {
         if timeoutInMillis.int64Value >= 0 {
             self.sessionTimeoutInMillis = timeoutInMillis.uint64Value
         }
+        return self
+    }
+
+    /**
+     Sets whether background events should update the session's last activity timestamp. Only applies when automatic session tracking is enabled.
+
+     - Parameter updateSessionOnBackgroundEvents: When `true`, background events update the session's last activity timestamp, extending the session timeout.
+     - Returns: The builder instance for chaining.
+     */
+    @objc
+    @discardableResult
+    public func setUpdateSessionOnBackgroundEvents(_ updateSessionOnBackgroundEvents: Bool) -> Self {
+        self.updateSessionOnBackgroundEvents = updateSessionOnBackgroundEvents
         return self
     }
 }

--- a/Sources/RudderStackAnalytics/Plugins/Standard/SessionTrackingPlugin.swift
+++ b/Sources/RudderStackAnalytics/Plugins/Standard/SessionTrackingPlugin.swift
@@ -36,8 +36,10 @@ final class SessionTrackingPlugin: Plugin {
             sessionHandler.updateSessionStart(isSessionStart: false)
         }
         
-        if sessionSnapshot.type == .automatic {
+        if sessionSnapshot.type == .automatic && sessionHandler.shouldUpdateActivityTimeForEvent() {
             sessionHandler.updateSessionLastActivityTime()
+        } else if sessionSnapshot.type == .automatic {
+            LoggerAnalytics.debug("SessionTrackingPlugin: Not updating activity time for event - app is in the background and background event updates are disabled.")
         }
         
         return info

--- a/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
+++ b/Sources/RudderStackAnalytics/SessionManagement/SessionHandler.swift
@@ -25,6 +25,8 @@ final class SessionHandler {
     private var sessionInstance: SessionInfo { self.sessionState.state.value }
     private var sessionCofiguration: SessionConfiguration { analytics.configuration.sessionConfiguration }
     private var automaticSessionTimeout: UInt64 { self.sessionCofiguration.sessionTimeoutInMillis }
+    // Setting it to "true" by default, as lifecycle callback is not being fired, when the app is launched for the first time.
+    @Synchronized private var isInForeground: Bool = true
     
     var analytics: Analytics
     
@@ -89,10 +91,12 @@ extension SessionHandler: LifecycleEventListener {
     // MARK: - Lifecycle Event Handlers
     
     func onBackground() {
+        self.isInForeground = false
         self.updateSessionLastActivityTime()
     }
     
     func onForeground() {
+        self.isInForeground = true
         guard self.sessionId != nil, self.sessionType == .automatic, self.isSessionTimedOut else { return }
         self.startSession(id: Self.generatedSessionId, type: .automatic)
     }
@@ -138,6 +142,10 @@ extension SessionHandler {
         let millisecondsInSecond: TimeInterval = 1000.0
         let interval = Date().timeIntervalSince1970
         return interval > 0 ? UInt64(interval * millisecondsInSecond) : 0
+    }
+    
+    func shouldUpdateActivityTimeForEvent() -> Bool {
+        return sessionCofiguration.updateSessionOnBackgroundEvents || isInForeground
     }
     
     /**

--- a/Tests/RudderStackAnalyticsTests/Plugins/Basic/SessionTrackingPluginTests.swift
+++ b/Tests/RudderStackAnalyticsTests/Plugins/Basic/SessionTrackingPluginTests.swift
@@ -72,4 +72,48 @@ class SessionTrackingPluginTests {
         #expect(sessionTrackingPlugin.analytics != nil)
         #expect(sessionTrackingPlugin.pluginType == .preProcess)
     }
+
+    @Test("given app is backgrounded and updateSessionOnBackgroundEvents is false, when intercepting an automatic session event, then last activity time is not updated")
+    func testInterceptDoesNotUpdateActivityTimeForBackgroundEvent() {
+        let sessionConfig = SessionConfiguration(automaticSessionTracking: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: sessionConfig)
+        sessionTrackingPlugin.setup(analytics: analytics)
+        let sessionHandler = analytics.sessionHandler
+        sessionHandler?.onBackground()
+        let activityTimeBeforeEvent = sessionHandler?.lastActivityTime
+
+        _ = sessionTrackingPlugin.intercept(event: MockProvider.mockTrackEvent)
+
+        #expect(sessionHandler?.lastActivityTime == activityTimeBeforeEvent)
+    }
+
+    @Test("given app is backgrounded and updateSessionOnBackgroundEvents is true, when intercepting an automatic session event, then last activity time is updated")
+    func testInterceptUpdatesActivityTimeForBackgroundEventWhenEnabled() {
+        let sessionConfig = SessionConfiguration(automaticSessionTracking: true, updateSessionOnBackgroundEvents: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: sessionConfig)
+        sessionTrackingPlugin.setup(analytics: analytics)
+        let sessionHandler = analytics.sessionHandler
+        sessionHandler?.onBackground()
+        // Reset to a known past value so the update produces a strictly different result
+        sessionHandler?.updateSessionLastActivityTime(0)
+        let activityTimeBeforeEvent = sessionHandler?.lastActivityTime
+
+        _ = sessionTrackingPlugin.intercept(event: MockProvider.mockTrackEvent)
+
+        #expect(sessionHandler?.lastActivityTime != activityTimeBeforeEvent)
+    }
+
+    @Test("given app is in foreground, when intercepting an automatic session event, then last activity time is updated")
+    func testInterceptUpdatesActivityTimeForForegroundEvent() {
+        let sessionConfig = SessionConfiguration(automaticSessionTracking: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: sessionConfig)
+        sessionTrackingPlugin.setup(analytics: analytics)
+        let sessionHandler = analytics.sessionHandler
+        sessionHandler?.onForeground()
+        let activityTimeBeforeEvent = sessionHandler?.lastActivityTime
+
+        _ = sessionTrackingPlugin.intercept(event: MockProvider.mockTrackEvent)
+
+        #expect(sessionHandler?.lastActivityTime != activityTimeBeforeEvent)
+    }
 }

--- a/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/SessionManagement/SessionHandlerTests.swift
@@ -330,6 +330,48 @@ struct SessionHandlerTests {
         #expect(sessionHandler.lastActivityTime >= beforeTime)
         #expect(sessionHandler.lastActivityTime <= afterTime)
     }
+
+    // MARK: - Background/Foreground Activity Guard Tests
+
+    @Test("given session handler is freshly created, when shouldUpdateActivityTimeForEvent is called, then it returns true")
+    func givenSessionHandlerIsFreshlyCreated_whenShouldUpdateActivityTimeForEventIsCalled_thenItReturnsTrue() {
+        let configuration = SessionConfiguration(automaticSessionTracking: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
+        let sessionHandler = SessionHandler(analytics: analytics)
+
+        #expect(sessionHandler.shouldUpdateActivityTimeForEvent())
+    }
+
+    @Test("given app is backgrounded and updateSessionOnBackgroundEvents is false, when shouldUpdateActivityTimeForEvent is called, then it returns false")
+    func givenAppIsBackgroundedAndUpdateSessionOnBackgroundEventsIsFalse_whenShouldUpdateActivityTimeForEventIsCalled_thenItReturnsFalse() {
+        let configuration = SessionConfiguration(automaticSessionTracking: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
+        let sessionHandler = SessionHandler(analytics: analytics)
+        sessionHandler.onBackground()
+
+        #expect(!sessionHandler.shouldUpdateActivityTimeForEvent())
+    }
+
+    @Test("given app is backgrounded and updateSessionOnBackgroundEvents is true, when shouldUpdateActivityTimeForEvent is called, then it returns true")
+    func givenAppIsBackgroundedAndUpdateSessionOnBackgroundEventsIsTrue_whenShouldUpdateActivityTimeForEventIsCalled_thenItReturnsTrue() {
+        let configuration = SessionConfiguration(automaticSessionTracking: true, updateSessionOnBackgroundEvents: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
+        let sessionHandler = SessionHandler(analytics: analytics)
+        sessionHandler.onBackground()
+
+        #expect(sessionHandler.shouldUpdateActivityTimeForEvent())
+    }
+
+    @Test("given app is backgrounded then foregrounded, when shouldUpdateActivityTimeForEvent is called, then it returns true")
+    func givenAppIsBackgroundedThenForegrounded_whenShouldUpdateActivityTimeForEventIsCalled_thenItReturnsTrue() {
+        let configuration = SessionConfiguration(automaticSessionTracking: true)
+        let analytics = MockProvider.createMockAnalytics(sessionConfig: configuration)
+        let sessionHandler = SessionHandler(analytics: analytics)
+        sessionHandler.onBackground()
+        sessionHandler.onForeground()
+
+        #expect(sessionHandler.shouldUpdateActivityTimeForEvent())
+    }
     
     // MARK: - Foreground Tests
     


### PR DESCRIPTION
## Description

Sessions should reflect user-perceived engagement, not background activity. Customers reported sessions not resetting after background activity and ghost restarts — events fired whilst the app was in the background were updating the session's last activity timestamp, silently extending the session and preventing proper timeout/reset on the next foreground transition. The fix ensures sessions accurately reflect actual user engagement.

This PR adds an opt-in configuration toggle `updateSessionOnBackgroundEvents` to `SessionConfiguration` (defaults to `false`). When disabled, background events no longer extend session timeouts. Existing integrations that relied on the old behaviour can opt back in by setting it to `true`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `updateSessionOnBackgroundEvents` property to `SessionConfiguration` with a default of `false`
- Track foreground/background state via an `@Synchronized` flag `isInForeground` in `SessionHandler`, updated through lifecycle observer callbacks
- Gate `updateLastActivityTime` calls through `SessionHandler.shouldUpdateActivityTimeForEvent()`, which checks both the toggle and the current foreground state
- Added Objective-C compatibility support via `ObjCSessionConfigurationBuilder.setUpdateSessionOnBackgroundEvents()`

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimised if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

1. **Default behaviour (background events ignored):** Configure the SDK with default `SessionConfiguration`. Send events whilst the app is backgrounded — verify via debug logs that session activity time is NOT updated (look for the skip log message) and sessions timeout correctly on the next foreground transition.
2. **Opt-in behaviour (background events extend session):** Set `updateSessionOnBackgroundEvents = true`. Send events whilst backgrounded — verify that session activity time IS updated and the session remains active.
3. **Foreground events unaffected:** Regardless of the toggle value, events sent whilst the app is in the foreground should always update session activity time.
4. **Manual sessions unaffected:** When using manual session tracking, the toggle should have no effect — activity time is never auto-updated.

## Breaking Changes

The new property defaults to `false`, which changes the effective behaviour (background events no longer extend sessions), but this is the intended correction. Customers who relied on the previous behaviour can restore it by setting `updateSessionOnBackgroundEvents = true`.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Additional Context

- The **Application Backgrounded event** does not update lastActivityTimestamp, as it is triggered only after the app transitions to the background state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether background events extend session timeout when automatic session tracking is enabled (exposed in Swift and Objective-C).
  * Session activity updates now respect the new setting and foreground/background state.

* **Tests**
  * Added unit tests covering session behavior for background/foreground transitions and the new configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-sdk-swift/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->