### PR TITLE
ci(workflows): skip PR validation re-runs on description-only edits

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,42 @@
+# PR Title Validation Workflow
+#
+# Triggered on every PR opened, reopened, or edited against:
+#   main, develop, feat/*, refactor/*, release/*, ci/*, fix/*
+#
+# This workflow is intentionally separate from pr-validation.yml. It owns the
+# `edited` trigger so that PR title changes are re-validated without re-running
+# the heavy lint/test/build pipeline. pr-validation.yml only listens to
+# opened/reopened/synchronize, so body-only edits no longer cause CI churn while
+# title edits still get checked here.
+#
+# Permissions: contents:read only — this workflow does not write to issues, PRs,
+# or any other resources.
+
+name: PR Title Validation
+
+on:
+  pull_request:
+    branches: [ "main", "develop", "feat/*", "refactor/*", "release/*", "ci/*", "fix/*" ]
+    types: [ "opened", "reopened", "edited" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Validates the PR title follows RudderLabs conventional commit standards.
+  # Delegates to the shared rudderlabs/github-action-check-pr-title action.
+  pr-title-check:
+    name: PR Title Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Validate PR title
+        uses: rudderlabs/github-action-check-pr-title@0a83071336f7d6417249629f67a64530fcecda2e # v1.0.11

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -174,7 +174,10 @@ jobs:
         run: xcodebuild build -scheme RudderStackAnalytics -destination 'generic/platform=watchOS' | xcpretty
 
   # Aggregates results from all jobs and sends a Slack notification.
-  # Always runs — even if upstream jobs fail — so the team is always notified.
+  # Runs whenever the should-run gate has passed, regardless of whether upstream
+  # validation jobs succeeded or failed — so the team is always notified for any
+  # validation run that actually executed. Skipped when should-run is skipped
+  # (body-only PR edits) or fails, since there are no validation results to report.
   pr-validation-summary:
     name: PR Validation Summary
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,36 +1,31 @@
 # PR Validation Workflow
 #
-# Triggered on every PR opened, reopened, updated, or edited against:
+# Triggered on every PR opened, reopened, or updated against:
 #   main, develop, feat/*, refactor/*, release/*, ci/*, fix/*
 #
 # Job execution order:
 #
-#                  ┌─→ pr-title-check     ──┐
-#   should-run ──→ ├─→ sonarcloud-analysis ─┤
-#                  ├─→ swiftlint-check    ──┤──→ build-check ──→ pr-validation-summary
-#                  └─→ test-check         ──┘
+#   ┌─→ sonarcloud-analysis ─┐
+#   ├─→ swiftlint-check    ──┤──→ build-check ──→ pr-validation-summary
+#   └─→ test-check         ──┘
 #
-# - should-run is a fast gate that filters `edited` events: it only proceeds when the
-#   edit touches the PR title or base branch (i.e. github.event.changes.title|base is
-#   set). Body-only edits skip the entire pipeline. Other event types (opened,
-#   reopened, synchronize) always pass the gate.
-# - pr-title-check, sonarcloud-analysis, swiftlint-check, and test-check all run in parallel.
+# - sonarcloud-analysis, swiftlint-check, and test-check all run in parallel.
 # - build-check runs only after swiftlint-check and test-check both pass.
-# - pr-validation-summary runs last (always when validation ran), aggregates results,
-#   and sends a Slack notification. It is also skipped on body-only edits.
+# - pr-validation-summary runs last, aggregates results, and sends a Slack notification.
 # - Concurrency: duplicate runs for the same PR are cancelled automatically.
 #
 # Permissions: contents:read only — no jobs write to issues, PRs, or any other resources.
 #
-# Note: CodeQL security scanning is handled by the codeql.yml workflow which triggers
-#       automatically on every PR alongside these checks.
+# Note: PR title validation lives in the dedicated pr-title-validation.yml workflow,
+#       which owns the `edited` trigger so body-only PR edits don't re-run this
+#       heavy pipeline. CodeQL security scanning is handled by codeql.yml.
 
 name: PR Validation
 
 on:
   pull_request:
     branches: [ "main", "develop", "feat/*", "refactor/*", "release/*", "ci/*", "fix/*" ]
-    types: [ "opened", "reopened", "synchronize", "edited" ]
+    types: [ "opened", "reopened", "synchronize" ]
 
 permissions:
   contents: read
@@ -40,48 +35,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Fast gate that filters out PR `edited` events which don't affect validation.
-  # GitHub fires `edited` on title, body, and base-branch changes; only title and
-  # base changes need to retrigger the pipeline. Body-only edits skip everything.
-  # All other event actions (opened, reopened, synchronize) pass through.
-  should-run:
-    name: Should Run Validation
-    runs-on: ubuntu-latest
-    if: >-
-      github.event.action != 'edited' ||
-      github.event.changes.title != null ||
-      github.event.changes.base != null
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Report gate result
-        run: echo "Validation will run for event action '${{ github.event.action }}'."
-
-  # Validates the PR title follows RudderLabs conventional commit standards.
-  # Delegates to the shared rudderlabs/github-action-check-pr-title action.
-  pr-title-check:
-    name: PR Title Check
-    runs-on: ubuntu-latest
-    needs: [ should-run ]
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Validate PR title
-        uses: rudderlabs/github-action-check-pr-title@0a83071336f7d6417249629f67a64530fcecda2e # v1.0.11
-
   # Runs SonarCloud code quality analysis on the codebase.
   # Runs in parallel with other checks — independent of all other jobs.
   sonarcloud-analysis:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     environment: sonarcloud
-    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -104,7 +63,6 @@ jobs:
   swiftlint-check:
     name: SwiftLint Check
     runs-on: macos-latest
-    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -128,7 +86,6 @@ jobs:
   test-check:
     name: Unit Tests
     runs-on: macos-latest
-    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -174,16 +131,14 @@ jobs:
         run: xcodebuild build -scheme RudderStackAnalytics -destination 'generic/platform=watchOS' | xcpretty
 
   # Aggregates results from all jobs and sends a Slack notification.
-  # Runs whenever the should-run gate has passed, regardless of whether upstream
-  # validation jobs succeeded or failed — so the team is always notified for any
-  # validation run that actually executed. Skipped when should-run is skipped
-  # (body-only PR edits) or fails, since there are no validation results to report.
+  # Runs regardless of whether upstream validation jobs succeeded or failed, so the
+  # team is always notified for every validation run.
   pr-validation-summary:
     name: PR Validation Summary
     runs-on: ubuntu-latest
     environment: notifications
-    needs: [ should-run, pr-title-check, sonarcloud-analysis, swiftlint-check, test-check, build-check ]
-    if: always() && needs.should-run.result == 'success'
+    needs: [ sonarcloud-analysis, swiftlint-check, test-check, build-check ]
+    if: always()
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -199,7 +154,6 @@ jobs:
         id: summary
         run: |
           echo "=== PR Validation Summary ==="
-          echo "PR Title Check:      ${{ needs.pr-title-check.result }}"
           echo "SonarCloud Analysis: ${{ needs.sonarcloud-analysis.result }}"
           echo "SwiftLint Check:     ${{ needs.swiftlint-check.result }}"
           echo "Unit Tests:          ${{ needs.test-check.result }}"
@@ -208,11 +162,6 @@ jobs:
 
           FAILED_CHECKS=""
           OVERALL_STATUS="passed"
-
-          if [[ "${{ needs.pr-title-check.result }}" != "success" ]]; then
-            FAILED_CHECKS="${FAILED_CHECKS}• PR Title Check (${{ needs.pr-title-check.result }}) - Check title format follows conventional commits\n"
-            OVERALL_STATUS="failed"
-          fi
 
           if [[ "${{ needs.sonarcloud-analysis.result }}" != "success" ]]; then
             FAILED_CHECKS="${FAILED_CHECKS}• SonarCloud Analysis (${{ needs.sonarcloud-analysis.result }}) - Code quality issues detected\n"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,14 +5,19 @@
 #
 # Job execution order:
 #
-#   pr-title-check     ──┐
-#   sonarcloud-analysis ─┤
-#   swiftlint-check    ──┤──→ build-check ──→ pr-validation-summary
-#   test-check         ──┘
+#                  ┌─→ pr-title-check     ──┐
+#   should-run ──→ ├─→ sonarcloud-analysis ─┤
+#                  ├─→ swiftlint-check    ──┤──→ build-check ──→ pr-validation-summary
+#                  └─→ test-check         ──┘
 #
+# - should-run is a fast gate that filters `edited` events: it only proceeds when the
+#   edit touches the PR title or base branch (i.e. github.event.changes.title|base is
+#   set). Body-only edits skip the entire pipeline. Other event types (opened,
+#   reopened, synchronize) always pass the gate.
 # - pr-title-check, sonarcloud-analysis, swiftlint-check, and test-check all run in parallel.
 # - build-check runs only after swiftlint-check and test-check both pass.
-# - pr-validation-summary runs last (always), aggregates results, and sends a Slack notification.
+# - pr-validation-summary runs last (always when validation ran), aggregates results,
+#   and sends a Slack notification. It is also skipped on body-only edits.
 # - Concurrency: duplicate runs for the same PR are cancelled automatically.
 #
 # Permissions: contents:read only — no jobs write to issues, PRs, or any other resources.
@@ -35,11 +40,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Fast gate that filters out PR `edited` events which don't affect validation.
+  # GitHub fires `edited` on title, body, and base-branch changes; only title and
+  # base changes need to retrigger the pipeline. Body-only edits skip everything.
+  # All other event actions (opened, reopened, synchronize) pass through.
+  should-run:
+    name: Should Run Validation
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.action != 'edited' ||
+      github.event.changes.title != null ||
+      github.event.changes.base != null
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Report gate result
+        run: echo "Validation will run for event action '${{ github.event.action }}'."
+
   # Validates the PR title follows RudderLabs conventional commit standards.
   # Delegates to the shared rudderlabs/github-action-check-pr-title action.
   pr-title-check:
     name: PR Title Check
     runs-on: ubuntu-latest
+    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -55,6 +81,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     environment: sonarcloud
+    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -77,6 +104,7 @@ jobs:
   swiftlint-check:
     name: SwiftLint Check
     runs-on: macos-latest
+    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -100,6 +128,7 @@ jobs:
   test-check:
     name: Unit Tests
     runs-on: macos-latest
+    needs: [ should-run ]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -150,8 +179,8 @@ jobs:
     name: PR Validation Summary
     runs-on: ubuntu-latest
     environment: notifications
-    needs: [ pr-title-check, sonarcloud-analysis, swiftlint-check, test-check, build-check ]
-    if: always()
+    needs: [ should-run, pr-title-check, sonarcloud-analysis, swiftlint-check, test-check, build-check ]
+    if: always() && needs.should-run.result == 'success'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
## Description
GitHub fires a single `edited` event for PR title, description, and base-branch changes — so today every description tweak re-runs the full `pr-validation.yml` pipeline (SonarCloud + SwiftLint + unit tests + multi-platform builds + Slack summary), burning CI minutes for changes that can't affect validation results.

This PR splits PR-title validation out of `pr-validation.yml` into a dedicated, lightweight `pr-title-validation.yml` workflow. The heavy pipeline now subscribes only to `opened`, `reopened`, and `synchronize`, so description-only edits no longer trigger it. Title edits still get re-validated because the new workflow owns the `edited` trigger.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
- `.github/workflows/pr-validation.yml`
  - Removed `edited` from `on.pull_request.types`; now listens only to `opened`, `reopened`, `synchronize`.
  - Removed the inline `pr-title-check` job (moved to the new workflow).
  - Updated the header comment block and job-flow diagram to reflect the new pipeline.
  - `pr-validation-summary` no longer needs `pr-title-check`; the PR-title row was dropped from the summary echo and from the failed-checks aggregation script.
- `.github/workflows/pr-title-validation.yml` (new)
  - Triggers on `opened`, `reopened`, `edited` for the same branch set as `pr-validation.yml`.
  - Single `pr-title-check` job on `ubuntu-latest` that hardens the runner via `step-security/harden-runner@v2.16.0` and validates the title via `rudderlabs/github-action-check-pr-title@v1.0.11`.
  - Mirrors the existing workflow's conventions: pinned action SHAs with version comments, `contents: read` permissions, and the same concurrency group pattern (cancel-in-progress on duplicate runs per PR).

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
Workflow changes only take effect once merged, so verification is primarily by inspection plus a post-merge sanity check:

1. Confirm both YAML files parse cleanly (CI's workflow validator will fail otherwise).
2. Open a test PR against `develop`:
   - On `opened` → both `PR Validation` and `PR Title Validation` should run.
   - Push a new commit (`synchronize`) → only `PR Validation` should run.
   - Edit only the PR description → neither workflow should run a new instance of `PR Validation`; `PR Title Validation` will run (cheap, title-only) but its title check still passes.
   - Edit the PR title → `PR Title Validation` should run and re-validate against conventional-commit rules; `PR Validation` should not run.
3. Confirm the Slack notification from `pr-validation-summary` still posts on the post-merge run against `develop` with the expected job results (no PR-title row).

## Breaking Changes
No breaking changes to consumers of the SDK. This is a CI-only change.

Internal CI behavior change: base-branch edits on a PR will no longer retrigger the heavy validation pipeline. In practice this is fine because `swift build`, `swift test`, and `swiftlint` all operate on HEAD and don't depend on the base; a `synchronize` from any follow-up push will pick up the new base if needed.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
No UI changes in this PR — CI workflow changes only.

## Additional Context
- The `types:` filter on `on.pull_request` only accepts event action names (`opened`, `edited`, …) and can't distinguish *what* changed inside an `edited` event. The body/title/base distinction lives in the event payload (`github.event.changes.*`) and can only be inspected inside a job's `if:` condition. Splitting into two workflows lets us draw the body-vs-title boundary at the trigger level instead of via an in-workflow gate job.
- Net effect: zero CI runs on body-only edits (previously: full pipeline); cheap title-only run on title edits (previously: full pipeline); full pipeline still runs on every code push as before.