### PR TITLE
chore(claude): add objc-bridge-sync skill

### DIFF
--- a/.claude/skills/objc-bridge-sync/SKILL.md
+++ b/.claude/skills/objc-bridge-sync/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: objc-bridge-sync
+description: Flag drift between public Swift types in Sources/RudderStackAnalytics/ and their @objc(RSS…) wrappers under Sources/RudderStackAnalytics/ObjC/. Use when the user types /objc-bridge-sync, or before pushing a branch whose diff touches a public Swift type that is ObjC-bridged.
+---
+
+# objc-bridge-sync
+
+This SDK ships a parallel Objective-C surface under `Sources/RudderStackAnalytics/ObjC/`. When a public Swift type changes, its `@objc(RSS…)` wrapper must change with it — there is no compiler check for this, and SwiftLint does not enforce it. This skill is the manual check.
+
+## When to run
+
+- User invokes `/objc-bridge-sync` explicitly.
+- User is about to push or open a PR and the branch diff modifies a file under `Sources/RudderStackAnalytics/` outside the `ObjC/` subdirectory.
+
+Do not run on diffs that only touch `Tests/`, `Examples/`, `ObjC/` alone, or non-public types.
+
+## Procedure
+
+1. **Collect candidate Swift files** from the diff. This repo uses `develop` as the integration branch (PRs merge into `develop`; `main` only advances on release), so diff against `origin/develop`:
+
+   ```bash
+   git diff origin/develop...HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
+   ```
+
+   If `origin/develop` is unreachable (no remote, detached state, fresh clone), try in order: `origin/main`, `main`, `develop`. If none resolve, fall back to working-tree changes only and warn the user that the diff base is unverified:
+
+   ```bash
+   git diff HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
+   ```
+
+   Always also run the working-tree diff and union its file list with the branch diff — committed work on a feature branch plus uncommitted tweaks both count, and the user may have either or both:
+
+   ```bash
+   git diff HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
+   ```
+
+2. **For each candidate file**, find the public type declarations actually touched by the diff (not just every public type in the file):
+
+   ```bash
+   git diff origin/develop...HEAD -- <file> \
+     | grep -E '^\+.*\bpublic\s+(class|struct|enum|protocol|actor|extension)\b'
+   ```
+
+   Skip the file if no public declaration appears in the diff hunks. For changes to existing public members, also grep the hunks for `^\+.*\bpublic\s+(var|let|func|init)\b` so renamed or new members on an unchanged type declaration are caught.
+
+3. **Classify the bridge pattern** for each public type `T`:
+
+   | Pattern | How to recognise | Wrapper file |
+   |---|---|---|
+   | **Direct `@objc(RSS<T>)`** | `T` itself carries `@objc(RSS<T>)` or `@objc` and inherits `NSObject` | none — `T` *is* its own bridge |
+   | **Builder wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>Builder)` and has a `build() -> T` method | `Sources/RudderStackAnalytics/ObjC/**/ObjC<T>.swift` |
+   | **Delegation wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>)` and holds a `let` reference of type `T` | `Sources/RudderStackAnalytics/ObjC/**/ObjC<T>.swift` |
+
+   **Filename convention:** the wrapper *file* is always `ObjC<T>.swift` regardless of pattern. The `Builder` suffix appears only in the `@objc(…)` symbol, not the filename. Example: `ObjC/Base/ObjCConfiguration.swift` declares `@objc(RSSConfigurationBuilder)`. Don't hunt for `ObjCConfigurationBuilder.swift` — it doesn't exist.
+
+   Locate wrappers with:
+
+   ```bash
+   grep -rln "@objc(RSS" Sources/RudderStackAnalytics/ObjC/
+   ```
+
+4. **Diff the public surface**:
+   - From `T.swift`: enumerate `public` properties, methods, and `init` parameters touched by the diff (see step 2's grep).
+   - From the wrapper file, enumerate `@objc`-exposed members:
+
+     ```bash
+     grep -nE '@objc(\([^)]*\))?\s+(public\s+)?(func|var|let)' <wrapper-file>
+     ```
+
+     For builder wrappers, also look for `func setX(_:)` setter methods that may not carry an explicit `@objc` attribute (they inherit it from the class-level `@objc(RSS…Builder)`).
+   - **For public protocols** (e.g. `Plugin`, `EventPlugin`, `IntegrationPlugin`), the wrapper is typically `ObjC<T>` as an `NSObject`-backed adapter class implementing forwarding. Diff added protocol requirements against the wrapper's `@objc` method list.
+   - Report:
+     - Swift members added or renamed with no matching wrapper member. (Treat a removed+added pair with a similar name/signature as a likely rename and flag both sides.)
+     - Wrapper members whose signature no longer matches the Swift side.
+     - Swift members removed but still exposed on the wrapper.
+
+5. **Handle new public types**:
+   - If the diff adds a new `public` type with no wrapper and the type is not in the allowlist below, ask the user: "Is `<TypeName>` intentionally Swift-only? If yes, I'll add it to the skill allowlist. If no, the wrapper goes at `Sources/RudderStackAnalytics/ObjC/<area>/ObjC<TypeName>.swift`."
+
+## Swift-only allowlist
+
+These public types are intentionally not 1:1 bridged. Do NOT flag changes to them as missing wrappers:
+
+- Concrete event structs: `TrackEvent`, `ScreenEvent`, `IdentifyEvent`, `GroupEvent`, `AliasEvent` — bridged via the generic `ObjCEvent` protocol adapter in `Sources/RudderStackAnalytics/ObjC/Events/ObjCEvent.swift`.
+- Plugin sub-protocols beyond `Plugin`, `EventPlugin`, `IntegrationPlugin` — only those three have ObjC analogs.
+- The `Logger` protocol — exposed via the `ObjCAnalyticsLogger` adapter, not as a wrapper class.
+- Internal-by-design helpers: any type without the `public` modifier (the diff filter already excludes these, but double-check before flagging).
+
+When adding to this list, edit this SKILL.md file directly — keeping the list inline ensures it goes through code review.
+
+## Report format
+
+One markdown section per candidate Swift type. Use `✓` and `⚠` so the user can scan quickly.
+
+```
+### Configuration  (Sources/RudderStackAnalytics/Base/Configuration.swift)
+Wrapper: ObjCConfigurationBuilder  (Sources/RudderStackAnalytics/ObjC/Base/ObjCConfiguration.swift)
+
+⚠ Missing on wrapper:
+  - public var gzipEnabled: Bool  → add `setGzipEnabled(_:)` to ObjCConfigurationBuilder
+  - public var flushAt: Int       → add `setFlushAt(_:)` to ObjCConfigurationBuilder
+
+✓ In sync:
+  - writeKey, dataPlaneUrl, controlPlaneUrl
+```
+
+End with a one-line summary: `N type(s) checked, M wrapper change(s) needed.`
+
+If no drift is found, the entire report can be a single line: `✓ All bridged types in this diff are in sync (N type(s) checked).`
+
+## Caveats
+
+- This is a heuristic — the report is a checklist for a human, not a guarantee. Always confirm the suggested wrapper edits compile and that the ObjC method signatures match the project's existing naming conventions (e.g., builder setters prefix with `set`, return `self` for chaining).
+- The skill does not run Swift compilation. If a flagged type involves Swift-only constructs (associated-value enums, generics, `async` without an ObjC completion-handler shim), call that out in the report rather than naively proposing a wrapper method.
+- Do not edit the wrapper files as part of this skill — only report. The user (or a follow-up edit task) makes the actual changes.

--- a/.claude/skills/objc-bridge-sync/SKILL.md
+++ b/.claude/skills/objc-bridge-sync/SKILL.md
@@ -16,30 +16,26 @@ Do not run on diffs that only touch `Tests/`, `Examples/`, `ObjC/` alone, or non
 
 ## Procedure
 
-1. **Collect candidate Swift files** from the diff. This repo uses `develop` as the integration branch (PRs merge into `develop`; `main` only advances on release), so diff against `origin/develop`:
+1. **Collect candidate Swift files** from the diff. This repo uses `develop` as the integration branch (PRs merge into `develop`; `main` only advances on release), so diff against `origin/develop`. With the second ref omitted, the three-dot form diffs the merge-base against the working tree — committed branch work and uncommitted tweaks are both collected in one pass:
 
    ```bash
-   git diff origin/develop...HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
+   git diff origin/develop... --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
    ```
 
-   If `origin/develop` is unreachable (no remote, detached state, fresh clone), try in order: `origin/main`, `main`, `develop`. If none resolve, fall back to working-tree changes only and warn the user that the diff base is unverified:
+   If `origin/develop` does not resolve (no remote, shallow or single-branch clone), fall back to the local `develop` branch. Whichever resolves is the **diff base** — reuse it for every diff command in the rest of this procedure. Do not substitute `main`/`origin/main`: `main` only advances on release, so diffing against it would flag changes already merged to `develop`. If neither ref resolves, there is no diff base; fall back to working-tree changes only and warn the user that the diff base is unverified:
 
    ```bash
    git diff HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
    ```
 
-   Always also run the working-tree diff and union its file list with the branch diff — committed work on a feature branch plus uncommitted tweaks both count, and the user may have either or both:
+2. **For each candidate file**, find the public type declarations actually touched by the diff (not just every public type in the file). Use the diff base resolved in step 1, in the same working-tree-inclusive three-dot form:
 
    ```bash
-   git diff HEAD --name-only -- 'Sources/RudderStackAnalytics/*' ':!Sources/RudderStackAnalytics/ObjC/*'
-   ```
-
-2. **For each candidate file**, find the public type declarations actually touched by the diff (not just every public type in the file):
-
-   ```bash
-   git diff origin/develop...HEAD -- <file> \
+   git diff <diff-base>... -- <file> \
      | grep -E '^\+.*\bpublic\s+(class|struct|enum|protocol|actor|extension)\b'
    ```
+
+   If step 1 found no diff base, inspect working-tree hunks instead: `git diff HEAD -- <file>`.
 
    Skip the file if no public declaration appears in the diff hunks. For changes to existing public members, also grep the hunks for `^\+.*\bpublic\s+(var|let|func|init)\b` so renamed or new members on an unchanged type declaration are caught.
 
@@ -48,26 +44,29 @@ Do not run on diffs that only touch `Tests/`, `Examples/`, `ObjC/` alone, or non
    | Pattern | How to recognise | Wrapper file |
    |---|---|---|
    | **Direct `@objc(RSS<T>)`** | `T` itself carries `@objc(RSS<T>)` or `@objc` and inherits `NSObject` | none — `T` *is* its own bridge |
-   | **Builder wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>Builder)` and has a `build() -> T` method | `Sources/RudderStackAnalytics/ObjC/**/ObjC<T>.swift` |
-   | **Delegation wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>)` and holds a `let` reference of type `T` | `Sources/RudderStackAnalytics/ObjC/**/ObjC<T>.swift` |
+   | **Builder wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>Builder)` and has a `build() -> T` method | usually `ObjC/**/ObjC<T>.swift` — resolve via the grep below |
+   | **Delegation wrapper** | a class in `ObjC/` is annotated `@objc(RSS<T>)` and holds a `let` reference of type `T` | usually `ObjC/**/ObjC<T>.swift` — resolve via the grep below |
 
-   **Filename convention:** the wrapper *file* is always `ObjC<T>.swift` regardless of pattern. The `Builder` suffix appears only in the `@objc(…)` symbol, not the filename. Example: `ObjC/Base/ObjCConfiguration.swift` declares `@objc(RSSConfigurationBuilder)`. Don't hunt for `ObjCConfigurationBuilder.swift` — it doesn't exist.
-
-   Locate wrappers with:
+   **Locating the wrapper file:** never guess from the filename — resolve it by grepping for the `@objc(RSS…)` symbol:
 
    ```bash
-   grep -rln "@objc(RSS" Sources/RudderStackAnalytics/ObjC/
+   grep -rln "@objc(RSS<T>" Sources/RudderStackAnalytics/ObjC/
    ```
+
+   The *usual* filename is `ObjC<T>.swift` with the `Builder` suffix only in the `@objc(…)` symbol (e.g. `ObjC/Base/ObjCConfiguration.swift` declares `@objc(RSSConfigurationBuilder)`), but this is not universal: `ObjC/StateManagement/ObjCResetEntriesBuilder.swift` (`@objc(RSSResetEntriesBuilder)`) and `ObjCResetOptionsBuilder.swift` (`@objc(RSSResetOptionsBuilder)`) carry the suffix in the filename too. The grep is authoritative; treat the filename only as a hint.
 
 4. **Diff the public surface**:
    - From `T.swift`: enumerate `public` properties, methods, and `init` parameters touched by the diff (see step 2's grep).
-   - From the wrapper file, enumerate `@objc`-exposed members:
+   - From the wrapper file, enumerate `@objc`-exposed members. In this codebase `@objc` is almost always on its own line, often with further attributes (`@discardableResult`, `@available`) between it and the declaration — a same-line grep finds nothing. Scan forward from each `@objc` to the next declaration line instead:
 
      ```bash
-     grep -nE '@objc(\([^)]*\))?\s+(public\s+)?(func|var|let)' <wrapper-file>
+     awk '/@objc/ { armed = 1 }
+          armed && !/private/ && /(^|[^A-Za-z0-9_])(func|var|let|init)[^A-Za-z0-9_]/ { print FILENAME ":" FNR ":" $0; armed = 0 }' <wrapper-file>
      ```
 
-     For builder wrappers, also look for `func setX(_:)` setter methods that may not carry an explicit `@objc` attribute (they inherit it from the class-level `@objc(RSS…Builder)`).
+     (The spelled-out character classes are deliberate — macOS BSD awk does not support `\b`, which silently matches nothing. The first rule also arms on the same line, so single-line `@objc public func …` declarations are caught too. The class-level `@objc(RSS…)` annotation may make the scan print the first non-private member after the class declaration even if it lacks its own `@objc` — such a member is NOT actually exposed to Objective-C; see the exposure rule below.)
+
+     Class-level `@objc(RSS…)` does NOT implicitly expose members (Swift 4 removed that inference, and this codebase never uses `@objcMembers`) — every exposed member needs its own `@objc`, and in the existing builder wrappers every `setX(_:)` and `build()` does carry one. So if a `public func`/`var` in a wrapper has no `@objc` of its own, do not count it as exposed: flag it as a probable bridge gap (the one current exception, `ObjCEvent.originalTimestamp`, is recorded in the allowlist below).
    - **For public protocols** (e.g. `Plugin`, `EventPlugin`, `IntegrationPlugin`), the wrapper is typically `ObjC<T>` as an `NSObject`-backed adapter class implementing forwarding. Diff added protocol requirements against the wrapper's `@objc` method list.
    - Report:
      - Swift members added or renamed with no matching wrapper member. (Treat a removed+added pair with a similar name/signature as a likely rename and flag both sides.)
@@ -77,11 +76,11 @@ Do not run on diffs that only touch `Tests/`, `Examples/`, `ObjC/` alone, or non
 5. **Handle new public types**:
    - If the diff adds a new `public` type with no wrapper and the type is not in the allowlist below, ask the user: "Is `<TypeName>` intentionally Swift-only? If yes, I'll add it to the skill allowlist. If no, the wrapper goes at `Sources/RudderStackAnalytics/ObjC/<area>/ObjC<TypeName>.swift`."
 
-## Swift-only allowlist
+## Allowlist: bridging exceptions
 
-These public types are intentionally not 1:1 bridged. Do NOT flag changes to them as missing wrappers:
+Not every public Swift symbol maps 1:1 onto its own wrapper member — some are intentionally Swift-only, others are bridged once in a shared place. Do NOT flag the following as missing:
 
-- Concrete event structs: `TrackEvent`, `ScreenEvent`, `IdentifyEvent`, `GroupEvent`, `AliasEvent` — bridged via the generic `ObjCEvent` protocol adapter in `Sources/RudderStackAnalytics/ObjC/Events/ObjCEvent.swift`.
+- Members the concrete event structs (`TrackEvent`, `ScreenEvent`, `IdentifyEvent`, `GroupEvent`, `AliasEvent`) inherit from the `Event` protocol are bridged once on the shared `ObjCEvent` base class (`@objc(RSSEvent)`, `Sources/RudderStackAnalytics/ObjC/Events/ObjCEvent.swift`): `anonymousId`, `userId`, `channel`, `integrations`, `context`, `traits`, `messageId`, `sentAt`, `type`, and `originalTimestamp` (the last is public on the base but carries no `@objc` — Swift-only by current state). Don't demand per-wrapper duplicates of these. Two `Event` members are the opposite — `options` and `userIdentity` are re-exposed on **each** concrete wrapper, not the base. Everything else on a concrete event struct IS 1:1 bridged: each has its own wrapper subclass (`ObjCTrackEvent`/`@objc(RSSTrackEvent)`, `ObjCScreenEvent`/`@objc(RSSScreenEvent)`, …) exposing the event-specific properties and initializers — changes to those members must be checked against the concrete wrapper as usual.
 - Plugin sub-protocols beyond `Plugin`, `EventPlugin`, `IntegrationPlugin` — only those three have ObjC analogs.
 - The `Logger` protocol — exposed via the `ObjCAnalyticsLogger` adapter, not as a wrapper class.
 - Internal-by-design helpers: any type without the `public` modifier (the diff filter already excludes these, but double-check before flagging).
@@ -92,7 +91,7 @@ When adding to this list, edit this SKILL.md file directly — keeping the list 
 
 One markdown section per candidate Swift type. Use `✓` and `⚠` so the user can scan quickly.
 
-```
+```text
 ### Configuration  (Sources/RudderStackAnalytics/Base/Configuration.swift)
 Wrapper: ObjCConfigurationBuilder  (Sources/RudderStackAnalytics/ObjC/Base/ObjCConfiguration.swift)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build, test, lint
+
+This is a Swift Package (`Package.swift`) — there is no `Podfile`, `Brewfile`, or makefile.
+
+```bash
+# Build the library + tests
+swift build --build-tests
+
+# Run the full test suite — MUST use --no-parallel (tests race on shared async state).
+swift test --skip-build --no-parallel
+
+# Run a single test or test class (XCTest filter syntax)
+swift test --no-parallel --filter RudderStackAnalyticsTests.EventQueueTests
+swift test --no-parallel --filter RudderStackAnalyticsTests.EventQueueTests/test_put_writesEvent
+
+# Lint (matches the CI swiftlint-check job)
+swiftlint lint
+
+# Cross-platform build check (CI runs this for iOS/tvOS/watchOS; macOS is covered by `swift test`)
+xcodebuild build -scheme RudderStackAnalytics -destination 'generic/platform=iOS'  | xcpretty
+xcodebuild build -scheme RudderStackAnalytics -destination 'generic/platform=tvOS' | xcpretty
+xcodebuild build -scheme RudderStackAnalytics -destination 'generic/platform=watchOS' | xcpretty
+```
+
+For interactive development, open `RudderStackAnalytics.xcworkspace` — it bundles the SDK with the primary sample app at `Examples/Main/SwiftUIExample/`. The standalone `.xcodeproj` is for the library alone. Sample apps under `Examples/Others/` use the SDK via a local SPM reference, so SDK edits show up immediately on rebuild.
+
+`sh scripts/setup-hooks.sh` (also triggered by Xcode on first build) installs three hooks from `scripts/git-hooks/`: `commit-msg` (Conventional Commits), `pre-commit`, and `pre-push` (the latter runs `swift build --build-tests && swift test --skip-build --no-parallel`). The pre-push hook only fires from a terminal — GUI clients skip it because macOS Gatekeeper blocks SPM from parsing `Package.swift` non-interactively — and CI enforces the same build+test.
+
+**Platform minimums** (`Package.swift`): iOS 15, macOS 12, tvOS 15, watchOS 8. Don't use newer-OS-only APIs without an `@available` / `if #available` guard, or the cross-platform `xcodebuild` jobs in CI will fail.
+
+## Architecture
+
+Event pipeline (everything pivots around this):
+
+```
+public API (track/screen/identify/group/alias)
+        │
+        ▼
+Analytics.processEventChannel (AsyncChannel<Event>)
+        │
+        ▼
+PluginChain.process(event)
+   ├── preProcess plugins  (context enrichment: DeviceInfo, OSInfo, AppInfo, Locale, TimeZone, Screen, Library, Network, Lifecycle, SessionTracking)
+   ├── onProcess plugins   (transforms / IntegrationsManagementPlugin → device-mode destinations)
+   └── terminal plugins    (RudderStackDataPlanePlugin → EventQueue)
+                                       │
+                                       ▼
+                          EventQueue (writeChannel ─► EventWriter ─► Storage ─► uploadChannel ─► EventUploader ─► HttpNetwork)
+```
+
+Key invariants:
+
+- **One `AsyncChannel<Event>` from public API to plugin chain**, then a second `writeChannel`/`uploadChannel` pair inside `EventQueue`. Writer and uploader are decoupled — writer batches into storage and signals the uploader by sending a batch reference over `uploadChannel`. Don't bypass this; in particular, don't call the data-plane network code directly from a plugin.
+- **`Analytics.setup()` order matters.** `LifecycleObserver` must be created before `SessionHandler` (session handler subscribes to lifecycle events). `pluginChain` is created before any default plugins are added. The default plugin add-order in `Analytics.setup()` is the actual execution order within each `PluginType` bucket — preserve it when adding new built-in plugins.
+- **Plugin types** (`PluginType` enum, `Plugins/Core/Plugin.swift`): `preProcess`, `onProcess`, `terminal`, `utility`. The chain processes in that order; `utility` plugins only run when invoked manually. Custom plugins implement `Plugin` (generic) or `EventPlugin` (typed `identify/track/screen/group/alias` callbacks). Integrations are a distinct subtype — `IntegrationPlugin` instances are routed to `IntegrationsController`, not the main `PluginChain`.
+- **State is Combine-based.** `StateImpl<T>` wraps a `CurrentValueSubject` and is mutated only via `dispatch(action:)` with a `StateAction` reducer. The two reducers are `UserIdentity` (user/anonymous IDs, traits) and `SourceConfig` (server-side source config). Anything that needs to react to config changes should subscribe to `analytics.sourceConfigState.state` (see `EventQueue.observeConfigAndUpdateSchedule`).
+- **Storage is a protocol composition.** `Storage = KeyValueStorage + EventStorage`. `BasicStorage` is the default; it switches between `DiskStore` and `MemoryStore` based on `StorageMode`. Key-value persistence (anonymousId, userId, traits) and batched event persistence go through the same `Storage` instance.
+- **Logger is per-instance.** `Analytics.logger` is built from `configuration.logger` + `configuration.logLevel` and wrapped in `AnalyticsLogger`, which enforces the level before delegating. The static `LoggerAnalytics` API is deprecated and being actively migrated off (see recent `migrate call sites to instance-based logger` / `migrate sample apps to per-instance logger` commits) — new code must use `analytics.logger` (or the `logger` computed property on the `Plugin` extension). Don't reintroduce static logging or revert call sites already moved off it.
+- **Flush behavior is policy-driven.** `FlushPolicy` implementations (`CountFlushPolicy`, `FrequencyFlushPolicy`, `StartupFlushPolicy`) are passed via `Configuration.flushPolicies` and queried by `EventWriter`. Network retry uses `ExponentialBackoffPolicy` via `BackoffPolicyHandler`.
+- **Public ObjC surface lives in `Sources/RudderStackAnalytics/ObjC/`.** Swift types exposed to ObjC are prefixed `RSS` via `@objc(RSS…)`. When changing a public type that's ObjC-bridged (`Configuration`, `Analytics`, event types, `RudderOption`, `SessionConfiguration`, etc.), update the matching `ObjC*.swift` wrapper. Run `/objc-bridge-sync` (`.claude/skills/objc-bridge-sync/`) before push to flag wrapper drift — it diffs the branch against `origin/develop` and reports any public Swift members missing on their `RSS…` wrapper.
+
+## Conventions enforced by CI / hooks
+
+- **Branch names**: `<type>/<description>` where type is one of `feat|fix|hotfix|refactor|release|docs|chore|test|ci`. `main` and `develop` are also valid. Enforced by `pre-push` and the `pr-title-check` workflow.
+- **Commit messages**: Conventional Commits (`type(optional-scope): description`, types `feat|fix|refactor|perf|style|test|docs|chore|build|ci|revert`). Merge commits are allowed as-is. Enforced by `commit-msg`.
+- **SwiftLint** runs on `Sources/RudderStackAnalytics/**` only (Tests and Examples are excluded). Notable opt-in rules: `force_unwrapping`, `missing_docs` (all `public` API must have doc comments), `no_magic_numbers`, `explicit_init`, `function_default_parameter_at_end`. Type body cap 600 lines, function body cap 125 lines.
+- **Public APIs require doc comments** (`missing_docs` is opt-in). All existing public types use markdown-style `/** … */` comments — match that style.
+
+## Testing notes
+
+- Test plans live in `Tests/RudderStackAnalyticsTests/TestPlans/` (excluded from the SPM target via `Package.swift`'s `exclude:`). Mocks/fixtures are under `MockResources/`.
+- Tests rely on async coordination through `AsyncChannel` and Combine; running in parallel is racy, hence the mandatory `--no-parallel`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ For interactive development, open `RudderStackAnalytics.xcworkspace` — it bund
 
 Event pipeline (everything pivots around this):
 
-```
+```text
 public API (track/screen/identify/group/alias)
         │
         ▼


### PR DESCRIPTION
## Description
Adds two Claude Code artifacts that improve agent productivity on this SDK without touching runtime code. `CLAUDE.md` documents the build/test/lint commands, the event-pipeline architecture, and the load-bearing invariants (plugin add-order, per-instance logger migration, ObjC bridge parity, etc.) so future agent sessions can be productive immediately. The new `objc-bridge-sync` skill, invoked via `/objc-bridge-sync`, flags drift between public Swift types under `Sources/RudderStackAnalytics/` and their `@objc(RSS…)` wrappers under `Sources/RudderStackAnalytics/ObjC/` — an invariant the compiler and SwiftLint cannot enforce today.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Add `CLAUDE.md` at the repo root covering: SPM build/test commands (with the mandatory `--no-parallel`), single-test filter syntax, `swiftlint lint`, cross-platform `xcodebuild` checks, platform minimums (iOS 15 / macOS 12 / tvOS 15 / watchOS 8), the event-pipeline diagram, key architectural invariants, and the conventions enforced by CI hooks.
- Cross-link the ObjC-bridge invariant bullet in `CLAUDE.md` to the new `/objc-bridge-sync` skill so future agents discover it.
- Add `.claude/skills/objc-bridge-sync/SKILL.md` as a project-scoped Claude Code skill. The skill diffs the branch against `origin/develop` (with graceful fallback to `origin/main`, `main`, `develop`, or working-tree only), classifies each touched public Swift type into one of three bridge patterns (direct `@objc(RSS<T>)`, builder wrapper, delegation wrapper), and reports any public Swift members missing on the matching `ObjC<T>.swift` wrapper as a per-type ✓ / ⚠ checklist.
- Encode the Swift-only allowlist inline in the skill (concrete event structs bridged via the generic `ObjCEvent` protocol; `Logger` adapted via `ObjCAnalyticsLogger`; plugin sub-protocols beyond the three with ObjC analogs) so the rule is reviewed in code rather than inferred.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- Open `CLAUDE.md` in the repo root and verify the build, test, lint, and `xcodebuild` commands run as documented (`swift build --build-tests`, `swift test --skip-build --no-parallel`, `swiftlint lint`).
- From a fresh Claude Code session in this repo, type `/objc-bridge-sync` on the current branch — expect `✓ All bridged types in this diff are in sync (0 type(s) checked).` because no files under `Sources/RudderStackAnalytics/` outside `ObjC/` are touched.
- For a positive end-to-end check, temporarily add a `public var foo: Bool = false` to `Sources/RudderStackAnalytics/Base/Configuration.swift`, re-run `/objc-bridge-sync`, and confirm the report names `Sources/RudderStackAnalytics/ObjC/Base/ObjCConfiguration.swift` as the wrapper to update. Discard the local edit afterwards.

## Breaking Changes
No breaking changes. Both files are additive documentation/tooling under `.claude/` and the repo root; no Swift source, public API, or build configuration is modified.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
No UI changes in this PR.

## Additional Context
- The `objc-bridge-sync` skill is a heuristic checklist for human reviewers, not a guarantee — it does not run Swift compilation and explicitly does not edit wrapper files. See the "Caveats" section in `.claude/skills/objc-bridge-sync/SKILL.md`.
- The skill is project-scoped (committed under `.claude/skills/`) so it ships with the repo and is available to every contributor running Claude Code, without per-user configuration.
- Diff base is `origin/develop` because `develop` is this repo's integration branch (PRs merge into `develop`; `main` only advances on release). The skill documents this rationale inline and includes fallbacks for clones without `origin/develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new skill document describing a manual process to detect drift between Swift public types and their Objective-C bridge wrappers, including how to identify affected types, classify bridge patterns, and report discrepancies.
  * Added repository guidance covering build/test/lint commands, platform requirements, analytics pipeline overview, CI conventions, and coding/testing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->