### PR TITLE
fix: correct logLevel filtering and clean up PermissionManager corruption

### DIFF
--- a/Examples/Main/SwiftUIExample/SwiftUIExample/Managers/PermissionManager.swift
+++ b/Examples/Main/SwiftUIExample/SwiftUIExample/Managers/PermissionManager.swift
@@ -22,28 +22,28 @@ enum PermissionType {
 
 /**
  Requests a sequence of iOS permissions and guarantees the completion is invoked.
- 
+
  ## Guarantees
  - **Order independent.** Any ordering of `[.idfa, .bluetooth, .pushNotification]` works.
  - **Simulator-safe.** Hardware that doesn't support a permission (BLE on simulator,
  push without entitlement, etc.) can't stall the chain — every wait has a timeout.
  - **Lifetime-safe.** The internal `Task` strongly retains `self` for the duration of
  the chain, so a local-scoped caller can't free the manager mid-flight.
- 
+
  ## Usage
  ```swift
     private let permissionManager = PermissionManager()
- 
+
     permissionManager.requestPermissions([.idfa, .pushNotification, .bluetooth]) {
     // Always called — even on simulator, even if the user denies permissions.
         AnalyticsManager.shared.initializeAnalyticsSDK()
     }
- 
+
     // In AppDelegate, forward BOTH success and failure to unblock the push step:
     func application(_: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken _: Data) {
         permissionManager.didRegisterForRemoteNotifications()
     }
- 
+
     func application(_: UIApplication, didFailToRegisterForRemoteNotificationsWithError _: Error) {
         permissionManager.didRegisterForRemoteNotifications()
     }
@@ -51,14 +51,14 @@ enum PermissionType {
  */
 @MainActor
 final class PermissionManager: NSObject {
-    
+
     // MARK: - Tunables
-    
+
     /// Time `centralManagerDidUpdateState` has to fire before we abandon the wait.
     /// Required because the simulator (no BLE hardware) sometimes never delivers
     /// a state transition.
     private static let bluetoothTimeoutNanos: UInt64 = 1 * NSEC_PER_SEC
-    
+
     /// Time the AppDelegate has to forward `didRegisterForRemoteNotifications()`
     /// after `registerForRemoteNotifications()`. Protects against simulators
     /// and apps without the push entitlement, where neither success nor failure
@@ -69,16 +69,16 @@ final class PermissionManager: NSObject {
     /// abandon the wait. Guards against background launches and other edge
     /// cases where the notification never arrives.
     private static let didBecomeActiveTimeoutNanos: UInt64 = 5 * NSEC_PER_SEC
-    
+
     // MARK: - State
-    
+
     private var centralManager: CBCentralManager?
     private var bluetoothContinuation: CheckedContinuation<Void, Never>?
     private var pushTokenContinuation: CheckedContinuation<Void, Never>?
     private var didBecomeActiveContinuation: CheckedContinuation<Void, Never>?
-    
+
     // MARK: - Public API
-    
+
     /// Request a sequence of permissions. `completion` is guaranteed to run on
     /// the main thread after the last permission resolves (or times out).
     func requestPermissions(_ permissions: [PermissionType], completion: @escaping () -> Void) {
@@ -91,57 +91,21 @@ final class PermissionManager: NSObject {
             completion()
         }
     }
-    
+
     /// async/await variant for callers that don't need a closure.
     func requestPermissions(_ permissions: [PermissionType]) async {
         for permission in permissions {
             await request(permission)
         }
     }
-    
+
     /// Forward from BOTH
     /// `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` AND
     /// `application(_:didFailToRegisterForRemoteNotificationsWithError:)`.
     func didRegisterForRemoteNotifications() {
         resumePushToken()
     }
-    
-    private func request(_ permission: PermissionType) async {
-        switch permission {
-        case .idfa:             await requestIDFA()
-        case .pushNotification: await requestPushNotification()
-        case .bluetooth:        await requestBluetooth()
-        }
-    
-    // MARK: - Public API
-    
-    /// Request a sequence of permissions. `completion` is guaranteed to run on
-    /// the main thread after the last permission resolves (or times out).
-    func requestPermissions(_ permissions: [PermissionType], completion: @escaping () -> Void) {
-        // The Task strongly captures `self`, so callers can store the manager
-        // wherever they like — it stays alive until the chain finishes.
-        Task {
-            for permission in permissions {
-                await self.request(permission)
-            }
-            completion()
-        }
-    }
-    
-    /// async/await variant for callers that don't need a closure.
-    func requestPermissions(_ permissions: [PermissionType]) async {
-        for permission in permissions {
-            await request(permission)
-        }
-    }
-    
-    /// Forward from BOTH
-    /// `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` AND
-    /// `application(_:didFailToRegisterForRemoteNotificationsWithError:)`.
-    func didRegisterForRemoteNotifications() {
-        resumePushToken()
-    }
-    
+
     private func request(_ permission: PermissionType) async {
         switch permission {
         case .idfa:             await requestIDFA()
@@ -167,7 +131,7 @@ extension PermissionManager {
             print("IDFA: \(idfa)")
         }
     }
-    
+
     /// Uses the selector-based observer API so we don't have to capture an
     /// `NSObjectProtocol` token inside a `@Sendable` notification closure.
     /// `removeObserver(self, name:)` correspondingly tears it down.
@@ -206,66 +170,16 @@ extension PermissionManager {
 
 // MARK: - Push Notification
 extension PermissionManager {
-    fileprivate func requestIDFA() async {
-        // ATT only presents the prompt while the app is foreground/active. If
-        // we're called from `didFinishLaunchingWithOptions`, wait for the
-        // didBecomeActive transition first.
-        if UIApplication.shared.applicationState != .active {
-            await waitForActive()
-        }
-        let status = await ATTrackingManager.requestTrackingAuthorization()
-        print("IDFA status: \(status.rawValue)")
-        if status == .authorized {
-            let idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString.lowercased()
-            print("IDFA: \(idfa)")
-        }
-    }
-    
-    /// Uses the selector-based observer API so we don't have to capture an
-    /// `NSObjectProtocol` token inside a `@Sendable` notification closure.
-    /// `removeObserver(self, name:)` correspondingly tears it down.
-    private func waitForActive() async {
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            didBecomeActiveContinuation = cont
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(handleDidBecomeActive),
-                name: UIApplication.didBecomeActiveNotification,
-                object: nil
-            )
-        }
-    }
-    
-    @objc private func handleDidBecomeActive() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-        let cont = didBecomeActiveContinuation
-        didBecomeActiveContinuation = nil
-        cont?.resume()
-    }
-}
+    fileprivate func requestPushNotification() async {
+        let center = UNUserNotificationCenter.current()
+        let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        print("Push authorization granted: \(granted)")
+        guard granted else { return }
 
-// MARK: - Push Notification
-extension PermissionManager {
-    fileprivate func requestPushNotification() async {
-        let center = UNUserNotificationCenter.current()
-        let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
-        print("Push authorization granted: \(granted)")
-        guard granted else { return }
-        
         UIApplication.shared.registerForRemoteNotifications()
         await waitForPushToken()
     }
-    
-    fileprivate func requestPushNotification() async {
-        let center = UNUserNotificationCenter.current()
-        let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
-        print("Push authorization granted: \(granted)")
-        guard granted else { return }
-        
-        UIApplication.shared.registerForRemoteNotifications()
-        await waitForPushToken()
-    }
-    
+
     private func waitForPushToken() async {
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             pushTokenContinuation = cont
@@ -279,7 +193,7 @@ extension PermissionManager {
             }
         }
     }
-    
+
     fileprivate func resumePushToken() {
         let cont = pushTokenContinuation
         pushTokenContinuation = nil
@@ -289,7 +203,7 @@ extension PermissionManager {
 
 // MARK: - Bluetooth
 extension PermissionManager: CBCentralManagerDelegate {
-    
+
     fileprivate func requestBluetooth() async {
         // If iOS already knows the answer, no permission alert will appear and
         // (on some platforms) the state callback won't fire either. Short-circuit.
@@ -297,7 +211,7 @@ extension PermissionManager: CBCentralManagerDelegate {
             print("Bluetooth authorization: \(CBCentralManager.authorization.rawValue)")
             return
         }
-        
+
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             bluetoothContinuation = cont
             centralManager = CBCentralManager(delegate: self, queue: .main)
@@ -312,7 +226,7 @@ extension PermissionManager: CBCentralManagerDelegate {
             }
         }
     }
-    
+
     nonisolated func centralManagerDidUpdateState(_ central: CBCentralManager) {
         // CBCentralManager was initialized with `queue: .main`, so this is
         // already on the main thread — but the protocol method isn't isolated,
@@ -331,7 +245,7 @@ extension PermissionManager: CBCentralManagerDelegate {
             self.resumeBluetooth()
         }
     }
-    
+
     private func resumeBluetooth() {
         let cont = bluetoothContinuation
         bluetoothContinuation = nil

--- a/RudderStackAnalytics.xcodeproj/project.pbxproj
+++ b/RudderStackAnalytics.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		53A83F9C2E9F750400DDA0CC /* MockStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A83F9B2E9F750400DDA0CC /* MockStorage.swift */; };
 		53AC39722E1533F300B8E16C /* RudderOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AC39712E1533F300B8E16C /* RudderOptionTests.swift */; };
 		53AC39B42E16FA6E00B8E16C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 53AC39B32E16FA6E00B8E16C /* PrivacyInfo.xcprivacy */; };
+		53C8B38B2FCEC7AE00337763 /* ConfigurationLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C8B38A2FCEC7AE00337763 /* ConfigurationLoggerTests.swift */; };
 		53DB9D3C2F4392AF004FB1A4 /* RetryMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53DB9D3B2F4392AF004FB1A4 /* RetryMetadata.swift */; };
 		53DB9D752F44515A004FB1A4 /* RetryHeadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53DB9D742F44515A004FB1A4 /* RetryHeadersProvider.swift */; };
 		53DB9D7A2F4454DD004FB1A4 /* PrimaryRetryHeadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53DB9D792F4454DD004FB1A4 /* PrimaryRetryHeadersProvider.swift */; };
@@ -275,6 +276,7 @@
 		53A83F9B2E9F750400DDA0CC /* MockStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorage.swift; sourceTree = "<group>"; };
 		53AC39712E1533F300B8E16C /* RudderOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RudderOptionTests.swift; sourceTree = "<group>"; };
 		53AC39B32E16FA6E00B8E16C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		53C8B38A2FCEC7AE00337763 /* ConfigurationLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLoggerTests.swift; sourceTree = "<group>"; };
 		53DB9D3B2F4392AF004FB1A4 /* RetryMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryMetadata.swift; sourceTree = "<group>"; };
 		53DB9D742F44515A004FB1A4 /* RetryHeadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryHeadersProvider.swift; sourceTree = "<group>"; };
 		53DB9D792F4454DD004FB1A4 /* PrimaryRetryHeadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryRetryHeadersProvider.swift; sourceTree = "<group>"; };
@@ -730,6 +732,7 @@
 			children = (
 				53DEA65C2E03D06F00D6C371 /* LoggerAnalyticsTests.swift */,
 				539001052EA11A7400DAC164 /* AnalyticsTests.swift */,
+				53C8B38A2FCEC7AE00337763 /* ConfigurationLoggerTests.swift */,
 				53E58C2D2FA141AC002556B9 /* AnalyticsLoggerTests.swift */,
 			);
 			path = Base;
@@ -1632,6 +1635,7 @@
 				85A10BC12EA0C19C00E47E01 /* CustomIntegrationPluginTests.swift in Sources */,
 				539001012EA110C300DAC164 /* BasicStorageTests.swift in Sources */,
 				53E777652EB5120C00564D61 /* ExponentialBackoffPolicyTests.swift in Sources */,
+				53C8B38B2FCEC7AE00337763 /* ConfigurationLoggerTests.swift in Sources */,
 				53DEA67A2E03D06F00D6C371 /* ScreenEventTests.swift in Sources */,
 				53A83F9C2E9F750400DDA0CC /* MockStorage.swift in Sources */,
 				53DEA67B2E03D06F00D6C371 /* TrackEventTests.swift in Sources */,

--- a/Sources/RudderStackAnalytics/Base/Configuration.swift
+++ b/Sources/RudderStackAnalytics/Base/Configuration.swift
@@ -117,8 +117,6 @@ public class Configuration: NSObject {
         self.collectDeviceId = collectDeviceId
         self.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents
         self.sessionConfiguration = sessionConfiguration
-        self.logger = logger ?? SwiftLogger()
-        self.logLevel = logLevel
     }
 }
 

--- a/Tests/RudderStackAnalyticsTests/Base/ConfigurationLoggerTests.swift
+++ b/Tests/RudderStackAnalyticsTests/Base/ConfigurationLoggerTests.swift
@@ -1,0 +1,111 @@
+//
+//  ConfigurationLoggerTests.swift
+//  RudderStackAnalytics
+//
+//  Created by Satheesh Kannan on 02/06/26.
+//
+
+import Testing
+import Foundation
+@testable import RudderStackAnalytics
+
+@Suite("Configuration Logger Wiring Tests")
+struct ConfigurationLoggerTests {
+
+    private func makeConfiguration(logger: Logger? = nil, logLevel: LogLevel? = nil) -> Configuration {
+        if let logLevel {
+            return Configuration(writeKey: MockConstant.mockWriteKey, dataPlaneUrl: MockConstant.mockDataPlaneUrl, logger: logger, logLevel: logLevel)
+        }
+        return Configuration(writeKey: MockConstant.mockWriteKey, dataPlaneUrl: MockConstant.mockDataPlaneUrl, logger: logger)
+    }
+
+    @Test("given no logger, when a Configuration is created, then logger is wrapped in a level-aware AnalyticsLogger")
+    func testDefaultLoggerIsWrapped() {
+        let config = makeConfiguration()
+        #expect(config.logger is AnalyticsLogger)
+    }
+
+    @Test("given only a logLevel and no custom logger, when a Configuration is created, then the default logger is wrapped in an AnalyticsLogger carrying that level",
+          arguments: [LogLevel.none, .error, .warn, .info, .debug, .verbose])
+    func testOnlyLogLevelSetUsesWrappedDefaultLogger(level: LogLevel) {
+        // No `logger:` argument — the SDK should fall back to its default sink,
+        // still wrapped so the level is honoured. The overwrite bug replaced this
+        // wrapper with a raw, unfiltered logger.
+        let config = makeConfiguration(logLevel: level)
+        #expect(config.logger is AnalyticsLogger)
+        #expect(config.logLevel == level)
+    }
+
+    @Test("given a custom logger, when a Configuration is created, then logger is still wrapped in AnalyticsLogger and not the raw logger")
+    func testCustomLoggerIsWrapped() {
+        let mockLogger = MockLogger()
+        let config = makeConfiguration(logger: mockLogger)
+        #expect(config.logger is AnalyticsLogger)
+        #expect(!(config.logger is MockLogger))
+    }
+
+    @Test("given logLevel none, when logging through Configuration.logger, then nothing is captured")
+    func testNoneLevelSuppressesAllLogs() {
+        let mockLogger = MockLogger()
+        let config = makeConfiguration(logger: mockLogger, logLevel: LogLevel.none)
+
+        config.logger.verbose(log: "verbose")
+        config.logger.debug(log: "debug")
+        config.logger.info(log: "info")
+        config.logger.warn(log: "warn")
+        config.logger.error(log: "error", error: nil)
+
+        #expect(mockLogger.logs.isEmpty)
+    }
+
+    @Test("given logLevel verbose, when logging through Configuration.logger, then every level is captured")
+    func testVerboseLevelLogsEverything() {
+        let mockLogger = MockLogger()
+        let config = makeConfiguration(logger: mockLogger, logLevel: .verbose)
+
+        config.logger.verbose(log: "verbose")
+        config.logger.debug(log: "debug")
+        config.logger.info(log: "info")
+        config.logger.warn(log: "warn")
+        config.logger.error(log: "error", error: nil)
+
+        let levels = mockLogger.logs.map { $0.level }
+        #expect(levels.contains("VERBOSE"))
+        #expect(levels.contains("DEBUG"))
+        #expect(levels.contains("INFO"))
+        #expect(levels.contains("WARN"))
+        #expect(levels.contains("ERROR"))
+    }
+
+    @Test("given an omitted logLevel, when a Configuration is created, then it defaults to none and suppresses logs")
+    func testDefaultLogLevelIsNone() {
+        let mockLogger = MockLogger()
+        let config = makeConfiguration(logger: mockLogger)
+
+        #expect(config.logLevel == .none)
+
+        config.logger.verbose(log: "verbose")
+        config.logger.error(log: "error", error: nil)
+
+        #expect(mockLogger.logs.isEmpty)
+    }
+
+    @Test("given logLevel warn, when logging through Configuration.logger, then only warn and error are captured")
+    func testWarnLevelFiltersLowerSeverity() {
+        let mockLogger = MockLogger()
+        let config = makeConfiguration(logger: mockLogger, logLevel: .warn)
+
+        config.logger.verbose(log: "verbose")
+        config.logger.debug(log: "debug")
+        config.logger.info(log: "info")
+        config.logger.warn(log: "warn")
+        config.logger.error(log: "error", error: nil)
+
+        let levels = mockLogger.logs.map { $0.level }
+        #expect(!levels.contains("VERBOSE"))
+        #expect(!levels.contains("DEBUG"))
+        #expect(!levels.contains("INFO"))
+        #expect(levels.contains("WARN"))
+        #expect(levels.contains("ERROR"))
+    }
+}


### PR DESCRIPTION
## Description
`Configuration.init` correctly built a level-aware `AnalyticsLogger` but then immediately overwrote `self.logger` with a raw, unfiltered `SwiftLogger`, causing the configured `logLevel` (including `.none`) to have no effect. The duplicate assignment lines were removed so the `AnalyticsLogger` wrapper is always the stored logger. 

Separately, `PermissionManager` in the SwiftUI sample app had duplicated method bodies, a missing closing brace, and a mislabeled extension — which were cleaned up with a complete rewrite to a single-copy, correctly structured file.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `Sources/RudderStackAnalytics/Base/Configuration.swift`: Removed the two duplicate assignments at the end of `init` (`self.logger = logger ?? SwiftLogger()` and the redundant `self.logLevel = logLevel`) that overwrote the correctly-built `AnalyticsLogger`.
- `Tests/RudderStackAnalyticsTests/Base/ConfigurationLoggerTests.swift`: Added a new test suite (7 tests) covering the `Configuration` logger-wiring layer — including a parameterized test across all 6 `LogLevel` values for the no-custom-logger path and filter-behavior tests for `.none`, `.verbose`, and `.warn`.
- `Examples/Main/SwiftUIExample/SwiftUIExample/Managers/PermissionManager.swift`: Rewrote to remove copy-paste corruption (duplicated blocks, missing brace, mislabeled extension). Clean single-copy structure with correct IDFA, Push Notification, and Bluetooth extensions.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Run the new `ConfigurationLoggerTests` suite — all 7 tests (including the 6-case parameterized test) should pass.
2. Initialize the SDK with `logLevel: .none` and confirm no logs appear in the console.
3. Initialize with `logLevel: .verbose` and confirm all log levels (verbose, debug, info, warn, error) are printed.
4. Initialize with a custom logger and `logLevel: .warn` — confirm only warn and error reach the custom logger.
5. Build the SwiftUIExample target — it should compile cleanly with no diagnostics from `PermissionManager.swift`.

## Breaking Changes
No breaking changes. The `Configuration` public API is unchanged; the fix only removes internal duplicate assignments that were silently discarding the correct value.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
No UI changes in this PR.

## Additional Context
The root cause of the `logLevel` bug was structurally identical to the `PermissionManager` corruption — both were duplicate-assignment patterns where the correct value was written first and then silently overwritten. The regression suite added here pins the `Configuration` wiring layer specifically so this class of bug cannot silently return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation and examples for permission request chains and timeout behavior.

* **Tests**
  * Added comprehensive test coverage for logger configuration, wrapping behavior, and log level filtering to ensure reliable logging across all severity levels.

* **Refactor**
  * Reorganized permission request flows including consolidated push-notification handling and improved Bluetooth permission management structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->