### PR TITLE
fix(NetworkMonitor): cancel NWPathMonitor in deinit to prevent resource leak

### DIFF
--- a/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
+++ b/Sources/RudderStackAnalytics/Helpers/Utils/NetworkInfoPluginUtils.swift
@@ -79,6 +79,10 @@ class NetworkMonitor: NetworkMonitorProtocol {
         monitor.start(queue: queue)
     }
     
+    deinit {
+        monitor.cancel()
+    }
+
     func cancel() {
         monitor.cancel()
     }


### PR DESCRIPTION
## Problem

`NetworkMonitor` starts an `NWPathMonitor` on a background `DispatchQueue` during `init()`, but never cancels it when the instance is deallocated. The `cancel()` method exists on the class but is never called automatically.

This means the `NWPathMonitor` and its background queue run for the entire process lifetime, even if the owning object is released. Instruments' **Leaks** instrument (Cycles & Roots view) flags this as `_NWPathMonitor - 2 nodes`.

## Root Cause

```swift
class NetworkMonitor: NetworkMonitorProtocol {
    private let monitor = NWPathMonitor()

    init() {
        // starts monitor on background queue
        monitor.start(queue: DispatchQueue(label: "NetworkMonitor"))
        ...
    }

    func cancel() { monitor.cancel() }  // exists but never called on dealloc
    // ❌ no deinit
}
```

## Fix

Add `deinit` to call the already-existing `cancel()`:

```swift
deinit {
    monitor.cancel()
}
```

This matches the pattern used in `Connectivity.swift` in this same codebase, which already has `deinit { stopMonitoring() }`.

## Impact

- Fixes `NWPathMonitor` running indefinitely after `NetworkMonitor` is released
- Prevents background `DispatchQueue` from staying alive unnecessarily
- No behaviour change when `NetworkMonitor` is long-lived (e.g. singleton usage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network monitoring resource management to ensure internal resources are properly released when the network monitor is no longer in use, preventing potential resource leaks in long-running applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->