### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Description

Adds a root `CODEOWNERS` file assigning the whole SDK team (`@rudderlabs/sdk_team`) as default code owners. This repo previously had no `CODEOWNERS`, so PRs did not auto-request reviews from anyone — despite `draft-new-release.yml` already noting "Reviewers are auto-assigned via CODEOWNERS", which this change makes true. With this in place, every PR auto-requests review from the SDK team and any team member's approval can unblock chore PRs (Dependabot merges, CI fixes). Part of the SDK-5102 rollout across SDK repos; resolves SDK-5109.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- New file `CODEOWNERS` at the repo root with a single rule: `* @rudderlabs/sdk_team`.
- `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors the team as code owner as soon as this merges — no access changes needed.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

Post-merge check: the next PR against `develop` should auto-request review from `@rudderlabs/sdk_team`, and any member's approval should satisfy the code-owner requirement. No code paths are affected, so no test runs are needed.

## Breaking Changes

None. Review-routing change only — no code, workflow, or build behavior is affected.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

No UI changes in this PR.

## Additional Context

Sibling PRs in the same rollout: rudderlabs/rudder-sdk-react-native#656 (merged), rudderlabs/rudder-sdk-ruby#49, rudderlabs/rudder-sdk-node#449, rudderlabs/rudder-sdk-flutter#313, rudderlabs/rudder-sdk-kotlin#327, rudderlabs/rudder-sdk-.net#38.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership metadata to assign designated maintainers for the relevant file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->